### PR TITLE
Check filenames against multiple patterns

### DIFF
--- a/test.py
+++ b/test.py
@@ -30,6 +30,22 @@ class TestNielsen(unittest.TestCase):
 				"extension": "avi"
 			},
 
+			"The Glades -02.01- Family Matters.avi": {
+				"series": "The Glades",
+				"season": "02",
+				"episode": "01",
+				"title": "Family Matters",
+				"extension": "avi"
+			},
+
+			"The Glades -201- Family Matters.avi": {
+				"series": "The Glades",
+				"season": "02",
+				"episode": "01",
+				"title": "Family Matters",
+				"extension": "avi"
+			},
+
 			"Supernatural.S10E15.mp4": {
 				"series": "Supernatural",
 				"season": "10",


### PR DESCRIPTION
- Check filenames against typical patterns for distribution and local
  organization. Return on the first match.
- Add two additional patterns to match against.
- Add tests for the new patterns.
- Zero-pad seasons to two digits.
- Resolves #5.