### PR TITLE
Use basename when getting file info

### DIFF
--- a/nielsen.py
+++ b/nielsen.py
@@ -62,7 +62,7 @@ def get_file_info(filename):
 
 	# Check against patterns until a matching one is found
 	for p in patterns:
-		m = p.match(filename)
+		m = p.match(path.basename(filename))
 		if m:
 			series = m.group("series").replace('.', ' ').strip()
 

--- a/test.py
+++ b/test.py
@@ -103,6 +103,14 @@ class TestNielsen(unittest.TestCase):
 				"extension": "mp4"
 			},
 
+			"supernatural.1117.hdtv-lol[ettv]/supernatural.1117.red.meat.hdtv-lol[ettv].mp4": {
+				"series": "Supernatural",
+				"season": "11",
+				"episode": "17",
+				"title": "Red Meat",
+				"extension": "mp4"
+			},
+
 			# "Bones.S04E01E02.720p.HDTV.X264-DIMENSION.mkv":
 			# "Bones -04.01-02- .mkv",
 		}


### PR DESCRIPTION
- Only match patterns against the `basename` of the file so that
  directories don't become part of the series name.
- Resolves #11.