### PR TITLE
Add pattern to allow single digit seasons

### DIFF
--- a/nielsen.py
+++ b/nielsen.py
@@ -47,13 +47,16 @@ def get_file_info(filename):
 		- extension: File extension
 	Filename variants:
 		The.Glades.S02E01.Family.Matters.HDTV.XviD-FQM.avi
+		the.glades.201.family.matters.hdtv.xvid-fqm.avi
 		The Glades -02.01- Family Matters.avi
 		The Glades -201- Family Matters.avi
 	"""
 
 	patterns = [
 		# The.Glades.S02E01.Family.Matters.HDTV.XviD-FQM.avi
-		re.compile(r"(?P<series>.+)\.+S?(?P<season>\d{2,})\.?E?(?P<episode>\d{2,})\.*(?P<title>.*)?\.+(?P<extension>\w+)$", re.IGNORECASE),
+		re.compile(r"(?P<series>.+)\.+S?(?P<season>\d{2})\.?E?(?P<episode>\d{2})\.*(?P<title>.*)?\.+(?P<extension>\w+)$", re.IGNORECASE),
+		# the.glades.201.family.matters.hdtv.xvid-fqm.avi
+		re.compile(r"(?P<series>.+)\.+S?(?P<season>\d{1,})\.?E?(?P<episode>\d{2,})\.*(?P<title>.*)?\.+(?P<extension>\w+)$", re.IGNORECASE),
 		# The Glades -02.01- Family Matters.avi
 		re.compile(r"(?P<series>.+)\s+-(?P<season>\d{2})\.(?P<episode>\d{2})-\s*(?P<title>.*)\.(?P<extension>.+)$"),
 		# The Glades -201- Family Matters.avi

--- a/test.py
+++ b/test.py
@@ -22,6 +22,14 @@ class TestNielsen(unittest.TestCase):
 				"extension": "avi"
 			},
 
+			"the.glades.s02e01.family.matters.hdtv.xvid-fqm.avi": {
+				"series": "The Glades",
+				"season": "02",
+				"episode": "01",
+				"title": "Family Matters",
+				"extension": "avi"
+			},
+
 			"The.Glades.S02E01.HDTV.XviD-FQM.avi": {
 				"series": "The Glades",
 				"season": "02",


### PR DESCRIPTION
- Modify first pattern to use exactly two digit seasons and episode
  numbers.
- Add new pattern which allows single digit seasons and more than two
  digit episodes.
- Resolves #15.