### PR TITLE
Add filter_series function to keep series names consistent

### DIFF
--- a/nielsen.py
+++ b/nielsen.py
@@ -74,7 +74,7 @@ def get_file_info(filename):
 				series = m.group("series").replace('.', ' ').title()
 
 			# Check series name against filter
-			# series = filter_series(series)
+			series = filter_series(series)
 
 			# Strip tags and release notes from the episode title
 			tags = re.compile(r"(HDTV|720p|WEB|PROPER|REPACK|RERIP).*", re.IGNORECASE)
@@ -120,6 +120,23 @@ def organize_file(filename, series, season):
 	else:
 		logging.error("No MediaPath defined.")
 		return None
+
+
+def filter_series(series):
+	"""Check series name against list and replace with preferred name.
+	Use the key/value pairs in the [Filters] section of the config file.
+	Match the series name against the left hand side (ignoring case) and
+	replace it with the right hand side.
+		Castle (2009) = Castle
+		Game Of Thrones = Game of Thrones
+		Its Always Sunny In Philadelphia = It's Always Sunny in Philadelphia
+		Marvel's Agents of S.H.I.E.L.D. = Agents of S.H.I.E.L.D.
+		Mr Robot = Mr. Robot
+	"""
+	if CONFIG.has_option('Filters', series):
+		return CONFIG['Filters'][series]
+	else:
+		return series
 
 
 def process_file(filename):

--- a/test.py
+++ b/test.py
@@ -80,7 +80,7 @@ class TestNielsen(unittest.TestCase):
 
 			# Title casing this will yield slightly incorrect results
 			"person.of.interest.s0310.the.devil's.share.hdtv.avi": {
-				"series": "Person Of Interest",
+				"series": "Person of Interest",
 				"season": "03",
 				"episode": "10",
 				"title": "The Devil'S Share",
@@ -88,7 +88,7 @@ class TestNielsen(unittest.TestCase):
 			},
 
 			"Castle.(2009).S07E18.720p.WEB-RiP.mp4": {
-				"series": "Castle (2009)",
+				"series": "Castle",
 				"season": "07",
 				"episode": "18",
 				"title": "",
@@ -96,7 +96,7 @@ class TestNielsen(unittest.TestCase):
 			},
 
 			"Castle.(2009).S01E01.Flowers.for.Your.Grave.720p.WEB-RiP.mp4": {
-				"series": "Castle (2009)",
+				"series": "Castle",
 				"season": "01",
 				"episode": "01",
 				"title": "Flowers for Your Grave",
@@ -119,12 +119,39 @@ class TestNielsen(unittest.TestCase):
 				"extension": "mp4"
 			},
 
+			"the.flash.(2014).217.hdtv-lol[ettv].mp4": {
+				"series": "The Flash",
+				"season": "02",
+				"episode": "17",
+				"title": "",
+				"extension": "mp4"
+			},
+
+			"The.Flash.2014.S02E17.HDTV.x264-LOL[ettv].mp4": {
+				"series": "The Flash",
+				"season": "02",
+				"episode": "17",
+				"title": "",
+				"extension": "mp4"
+			},
+
 			# "Bones.S04E01E02.720p.HDTV.X264-DIMENSION.mkv":
 			# "Bones -04.01-02- .mkv",
 		}
 
 		for path, info in file_names.items():
 			self.assertEqual(nielsen.get_file_info(path), info)
+
+	def test_filter_series(self):
+		self.assertEqual(nielsen.filter_series("Castle (2009)"), "Castle")
+		self.assertEqual(nielsen.filter_series("Dc'S Legends Of Tomorrow"), "Legends of Tomorrow")
+		self.assertEqual(nielsen.filter_series("Game Of Thrones"), "Game of Thrones")
+		self.assertEqual(nielsen.filter_series("It's Always Sunny In Philadelphia"), "It's Always Sunny in Philadelphia")
+		self.assertEqual(nielsen.filter_series("Its Always Sunny In Philadelphia"), "It's Always Sunny in Philadelphia")
+		self.assertEqual(nielsen.filter_series("Mr Robot"), "Mr. Robot")
+		self.assertEqual(nielsen.filter_series("Person Of Interest"), "Person of Interest")
+		self.assertEqual(nielsen.filter_series("The Flash (2014)"), "The Flash")
+		self.assertEqual(nielsen.filter_series("The Flash 2014"), "The Flash")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- Add `filter_series` function which checks its parameter against the
  [Filters] section of the config and returns the user specified name if
  found.
- Add and modify test cases for `get_file_info` which make use of
  `filter_series`.
- Add tests for `filter_series`.
- Resolves #2.