### PR TITLE
Add pattern to better handle a year specifier after the series name

### DIFF
--- a/nielsen.py
+++ b/nielsen.py
@@ -57,6 +57,8 @@ def get_file_info(filename):
 	"""
 
 	patterns = [
+		# The.Flash.2014.217.Flash.Back.HDTV.x264-LOL[ettv].mp4
+		re.compile(r"(?P<series>.+)\.+(?P<year>\d{4})\.(?P<season>\d{1,2})(?P<episode>\d{2})\.*(?P<title>.*)?\.+(?P<extension>\w+)$", re.IGNORECASE),
 		# The.Glades.S02E01.Family.Matters.HDTV.XviD-FQM.avi
 		re.compile(r"(?P<series>.+)\.+S?(?P<season>\d{2})\.?E?(?P<episode>\d{2})\.*(?P<title>.*)?\.+(?P<extension>\w+)$", re.IGNORECASE),
 		# the.glades.201.family.matters.hdtv.xvid-fqm.avi

--- a/test.py
+++ b/test.py
@@ -119,19 +119,27 @@ class TestNielsen(unittest.TestCase):
 				"extension": "mp4"
 			},
 
-			"the.flash.(2014).217.hdtv-lol[ettv].mp4": {
+			"the.flash.(2014).217.flash.back.hdtv-lol[ettv].mp4": {
 				"series": "The Flash",
 				"season": "02",
 				"episode": "17",
-				"title": "",
+				"title": "Flash Back",
 				"extension": "mp4"
 			},
 
-			"The.Flash.2014.S02E17.HDTV.x264-LOL[ettv].mp4": {
+			"The.Flash.2014.S02E17.Flash.Back.HDTV.x264-LOL[ettv].mp4": {
 				"series": "The Flash",
 				"season": "02",
 				"episode": "17",
-				"title": "",
+				"title": "Flash Back",
+				"extension": "mp4"
+			},
+
+			"The.Flash.2014.217.Flash.Back.HDTV.x264-LOL[ettv].mp4": {
+				"series": "The Flash",
+				"season": "02",
+				"episode": "17",
+				"title": "Flash Back",
 				"extension": "mp4"
 			},
 


### PR DESCRIPTION
- Add a pattern which should more accurately determine whether a four
  digit string after the name of the series is the year the series began
  or the season and episode number. This also prevents the actual
  season and episode number from being interpreted as the title of the
  episode.
- Add test cases to exercise the new pattern.
- Resolves #22.