### PR TITLE
Handle multi-episode files

### DIFF
--- a/nielsen.py
+++ b/nielsen.py
@@ -100,6 +100,13 @@ def get_file_info(filename):
 				'extension': m.group('extension').strip()
 			}
 
+			# Check for double episode files
+			# "Bones.S04E01E02.720p.HDTV.X264-DIMENSION.mkv":
+			if info['title'].lower().startswith("e") and info['title'][1:3].isnumeric():
+				if int(info['title'][1:3]) == int(info['episode']) + 1:
+					info['episode'] += "-" + info['title'][1:3]
+					info['title'] = info['title'][3:].strip()
+
 			logging.debug("Series: '{0}'".format(info['series']))
 			logging.debug("Season: '{0}'".format(info['season']))
 			logging.debug("Episode: '{0}'".format(info['episode']))

--- a/test.py
+++ b/test.py
@@ -151,8 +151,21 @@ class TestNielsen(unittest.TestCase):
 				"extension": "mkv"
 			},
 
-			# "Bones.S04E01E02.720p.HDTV.X264-DIMENSION.mkv":
-			# "Bones -04.01-02- .mkv",
+			"Bones.S04E01E02.720p.HDTV.X264-DIMENSION.mkv": {
+				"series": "Bones",
+				"season": "04",
+				"episode": "01-02",
+				"title": "",
+				"extension": "mkv"
+			},
+
+			"Sample.Show.S01E01.E19.Protocol.720p.HDTV.X264-DIMENSION.mkv": {
+				"series": "Sample Show",
+				"season": "01",
+				"episode": "01",
+				"title": "E19 Protocol",
+				"extension": "mkv"
+			},
 		}
 
 		for path, info in file_names.items():


### PR DESCRIPTION
- Check the title to see if it might be a multi-episode file.
- Add test cases for multi-episode filenames.
- Resolves #19.