### PR TITLE
Retrieve missing episode titles

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 """
 Config module for Nielsen.
+The CONFIG variable from this module should be imported into other modules as
+needed.
 """
 import configparser
 from os import getenv, name, path
@@ -19,7 +21,7 @@ CONFIG['DEFAULT'] = {
 
 
 def load_config(filename=None):
-	"""Load config file specified by path, or check XDG directories for
+	"""Load config file specified by filename, or check XDG directories for
 	configuration file."""
 	if filename and path.isfile(filename):
 		configfile = filename
@@ -39,6 +41,5 @@ def load_config(filename=None):
 		CONFIG.add_section('Options')
 	except configparser.DuplicateSectionError:
 		pass
-
 
 # vim: tabstop=4 softtabstop=4 shiftwidth=4 noexpandtab

--- a/nielsen.ini
+++ b/nielsen.ini
@@ -25,5 +25,6 @@ The Flash (2014) = The Flash
 The Flash 2014 = The Flash
 
 [IMDB]
-Castle = tt1219024
+Agents of SHIELD = tt2364582
 Archer = tt1486217
+Castle = tt1219024

--- a/nielsen.py
+++ b/nielsen.py
@@ -17,13 +17,15 @@ def get_file_info(filename):
 		- series: Series name
 		- season: Season number
 		- episode: Episode number
-		- title: Episode title (if found)
+		- title: Episode title (if found/enabled)
 		- extension: File extension
 	Filename variants:
+		The.Flash.2014.217.Flash.Back.HDTV.x264-LOL[ettv].mp4
 		The.Glades.S02E01.Family.Matters.HDTV.XviD-FQM.avi
 		the.glades.201.family.matters.hdtv.xvid-fqm.avi
 		The Glades -02.01- Family Matters.avi
 		The Glades -201- Family Matters.avi
+		Bones.S04E01E02.720p.HDTV.X264-DIMENSION.mkv
 	"""
 
 	patterns = [
@@ -69,15 +71,12 @@ def get_file_info(filename):
 					# Ensure we have a config section to keep track of IMDB IDs
 					CONFIG.add_section('IMDB')
 
-				if not CONFIG.has_option('IMDB', info['series']):
-					# Get IMDB ID of series if needed
-					CONFIG['IMDB'][info['series']] = titles.get_imdb_id(info['series'])
-
-				info['title'] = titles.get_episode_title(CONFIG.get('IMDB',
-					info['series']), info['season'], info['episode'])
+				# Get episode title from IMDB
+				info['title'] = titles.get_episode_title(
+					info['season'], info['episode'], series=info['series'])
 
 			# Check for double episode files
-			# "Bones.S04E01E02.720p.HDTV.X264-DIMENSION.mkv":
+			# Bones.S04E01E02.720p.HDTV.X264-DIMENSION.mkv
 			if info['title'].lower().startswith("e") and info['title'][1:3].isnumeric():
 				if int(info['title'][1:3]) == int(info['episode']) + 1:
 					info['episode'] += "-" + info['title'][1:3]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 pyxdg
+omdb

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from distutils.core import setup
 
 setup(
 	name='Nielsen',
-	version='0.8.0',
+	version='0.9.0',
 	author="Michael 'Irish' O'Neill",
 	author_email="irish.dot@gmail.com",
 	url='https://github.com/IrishPrime/nielsen/',
@@ -26,7 +26,7 @@ setup(
 	],
 	platforms='linux',
 	license='GNU General Public License v3 (GPLv3)',
-	py_modules=['nielsen', 'config'],
+	py_modules=['nielsen', 'config', 'titles'],
 )
 
 # vim: tabstop=4 softtabstop=4 shiftwidth=4 noexpandtab

--- a/test.py
+++ b/test.py
@@ -186,8 +186,13 @@ class TestNielsen(unittest.TestCase):
 
 class TestTitles(unittest.TestCase):
 
+	def test_get_imdb_id(self):
+		self.assertEqual(titles.get_imdb_id('Agents of SHIELD'), 'tt2364582')
+
+
 	def test_get_episode_title(self):
-		self.assertEqual(titles.get_episode_title('tt4532368', 1, 12), 'Last Refuge')
+		self.assertEqual(titles.get_episode_title(1, 12, imdb_id='tt4532368'), 'Last Refuge')
+		self.assertEqual(titles.get_episode_title(4, 2, series='Castle'), 'Heroes and Villains')
 
 
 if __name__ == "__main__":

--- a/test.py
+++ b/test.py
@@ -3,6 +3,7 @@
 
 import unittest
 import nielsen
+import titles
 
 
 class TestNielsen(unittest.TestCase):
@@ -181,6 +182,12 @@ class TestNielsen(unittest.TestCase):
 		self.assertEqual(nielsen.filter_series("Person Of Interest"), "Person of Interest")
 		self.assertEqual(nielsen.filter_series("The Flash (2014)"), "The Flash")
 		self.assertEqual(nielsen.filter_series("The Flash 2014"), "The Flash")
+
+
+class TestTitles(unittest.TestCase):
+
+	def test_get_episode_title(self):
+		self.assertEqual(titles.get_episode_title('tt4532368', 1, 12), 'Last Refuge')
 
 
 if __name__ == "__main__":

--- a/titles.py
+++ b/titles.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+"""Episode title module for nielsen."""
+
+import omdb
+
+
+def get_imdb_id(series):
+	"""Return the IMDB ID of a given series.
+	If an ID isn't found in the config, search IMDB and allow the user to
+	select a match."""
+	results = omdb.search_series(series)
+
+	if len(results) > 1:
+		for i, result in enumerate(results):
+			print("{0}. {1} ({2}) - {3}".format(i, result['title'], result['year'],
+				result['imdb_id']))
+
+		print("C. Cancel without a selection.")
+		selection = input("Select series: ")
+		return results[int(selection)]['imdb_id']
+	elif len(results) == 1:
+		return results[0]['imdb_id']
+	else:
+		return None
+
+
+def get_episode_title(imdb_id, season, episode):
+	"""Return the episode title using the IMDB ID, season, and episode number."""
+	return omdb.imdbid(imdb_id, season=season, episode=episode)['title']
+
+# vim: tabstop=4 softtabstop=4 shiftwidth=4 noexpandtab

--- a/titles.py
+++ b/titles.py
@@ -1,31 +1,55 @@
 #!/usr/bin/env python3
-"""Episode title module for nielsen."""
+"""
+Episode title module for Nielsen.
+Fetches information from IMDB through the omdb module.
+"""
 
 import omdb
+from config import CONFIG
 
 
 def get_imdb_id(series):
 	"""Return the IMDB ID of a given series.
 	If an ID isn't found in the config, search IMDB and allow the user to
 	select a match."""
+
+	if CONFIG.has_option('IMDB', series):
+		# Get IMDB ID of series if needed
+		return CONFIG['IMDB'][series]
+
 	results = omdb.search_series(series)
 
-	if len(results) > 1:
+	if len(results) == 1:
+		# If only one result, use it
+		return results[0]['imdb_id']
+	elif len(results) > 1:
+		# If multiple results, select one
+		print("Search results for '{0}'".format(series))
 		for i, result in enumerate(results):
 			print("{0}. {1} ({2}) - {3}".format(i, result['title'], result['year'],
 				result['imdb_id']))
+		print("Other input cancels without selection.")
 
-		print("C. Cancel without a selection.")
-		selection = input("Select series: ")
-		return results[int(selection)]['imdb_id']
-	elif len(results) == 1:
-		return results[0]['imdb_id']
+		try:
+			selection = int(input("Select series: "))
+			imdb_id = results[int(selection)]['imdb_id']
+			CONFIG['IMDB'][series] = imdb_id
+			return imdb_id
+		except (ValueError, IndexError, EOFError):
+			return None
+
+	return None
+
+
+def get_episode_title(season, episode, imdb_id=None, series=None):
+	"""Return the episode title using the series name or IMDB ID, season, and
+	episode number."""
+	if imdb_id is None and series:
+		imdb_id = get_imdb_id(series)
+
+	if imdb_id:
+		return omdb.imdbid(imdb_id, season=season, episode=episode)['title']
 	else:
 		return None
-
-
-def get_episode_title(imdb_id, season, episode):
-	"""Return the episode title using the IMDB ID, season, and episode number."""
-	return omdb.imdbid(imdb_id, season=season, episode=episode)['title']
 
 # vim: tabstop=4 softtabstop=4 shiftwidth=4 noexpandtab


### PR DESCRIPTION
- Add `titles` module.
- Fetch missing episode titles from IMDB (using `omdb`).
- Add `get_imdb_id` function to find the IMDB ID from either the config file, or interactively from IMDB.
- Add `get_episode_title` function to return the episode title given the season and episode number, and one of either the IMDB ID or series name.
- Bump version number.
- Add `titles` module to `setup.py`.