### PR TITLE
Prevent FileNotFoundError

### DIFF
--- a/nielsen/api.py
+++ b/nielsen/api.py
@@ -139,7 +139,11 @@ def filter_series(series):
 
 def process_file(filename):
 	"""Set ownership and permissions for files, then rename."""
-	logging.info("Processing '{0}'".format(filename))
+	if path.exists(filename):
+		logging.info("Processing '{0}'".format(filename))
+	else:
+		logging.info("File not found '{0}'".format(filename))
+		return None
 
 	if name == "posix":
 		if CONFIG['Options']['User'] or CONFIG['Options']['Group']:

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup
 
 setup(
 	name='Nielsen',
-	version='0.9.4',
+	version='0.9.5',
 	author="Michael 'Irish' O'Neill",
 	author_email="irish.dot@gmail.com",
 	url='https://github.com/IrishPrime/nielsen/',


### PR DESCRIPTION
- Check that file exists on any argument given to `process_file`.
- Bump version.
- Resolves #43.