### PR TITLE
Add IMDB IDs to config file before exiting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,4 @@ target/
 .*.swp
 *.mp4
 *.avi
+tags

--- a/nielsen/__init__.py
+++ b/nielsen/__init__.py
@@ -11,6 +11,7 @@ from .api import (
 from .config import (
 	CONFIG,
 	load_config,
+	update_imdb_ids,
 )
 
 from .titles import (

--- a/nielsen/config.py
+++ b/nielsen/config.py
@@ -24,26 +24,30 @@ CONFIG['Options'] = {
 }
 
 
-def load_config(filename=None):
-	"""Load config file specified by filename, or check XDG directories for
+def load_config(file_name=None):
+	"""Load config file specified by file_name, or check XDG directories for
 	configuration file."""
-	if filename and path.isfile(filename):
-		configfile = filename
+	if file_name and path.isfile(file_name):
+		config_file = file_name
 	else:
 		if name == "posix":
-			import xdg.BaseDirectory
-			configfile = xdg.BaseDirectory.load_first_config("nielsen/nielsen.ini")
+			config_file = ["/etc/xdg/nielsen/nielsen.ini",
+				"/etc/nielsen/nielsen.ini",
+				path.expanduser("~/.config/nielsen/nielsen.ini")]
 		elif name == "nt":
-			configfile = path.join("", getenv("APPDATA"), "nielsen", "nielsen.ini")
+			config_file = path.join("", getenv("APPDATA"), "nielsen", "nielsen.ini")
 
-	try:
-		CONFIG.read(configfile)
-	except:
-		print("Unable to load config: '{0}'".format(configfile))
+	return CONFIG.read(config_file)
 
-	try:
-		CONFIG.add_section('Options')
-	except configparser.DuplicateSectionError:
-		pass
+
+def update_imdb_ids(file_name=None):
+	"""Add imdb_ids to IMDB section of file_name or default user file."""
+	# Reloading the config will overwrite existing options from filename, but
+	# will not unset newly added options, so the IMDB section should be
+	# unaffected.
+	config_files = load_config(file_name)
+	file_name = config_files[-1]
+	with open(file_name, 'w') as f:
+		CONFIG.write(f)
 
 # vim: tabstop=4 softtabstop=4 shiftwidth=4 noexpandtab

--- a/nielsen/titles.py
+++ b/nielsen/titles.py
@@ -41,7 +41,7 @@ def get_imdb_id(series):
 
 	logging.info("IMDB ID for '{0}': {1}".format(series, imdb_id))
 	# Add whatever we find or select back to the config
-	CONFIG['IMDB'][series] = imdb_id
+	CONFIG.set('IMDB', series, imdb_id)
 
 	return imdb_id
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup
 
 setup(
 	name='Nielsen',
-	version='0.9.5',
+	version='0.9.6',
 	author="Michael 'Irish' O'Neill",
 	author_email="irish.dot@gmail.com",
 	url='https://github.com/IrishPrime/nielsen/',
@@ -27,7 +27,7 @@ setup(
 		'Topic :: Desktop Environment :: File Managers',
 		'Topic :: Multimedia :: Video',
 	],
-	install_requires=['pyxdg', 'omdb'],
+	install_requires=['omdb'],
 	entry_points={
 		'console_scripts': ['nielsen=nielsen.api:main'],
 	},

--- a/test.py
+++ b/test.py
@@ -8,7 +8,8 @@ import nielsen
 class TestConfig(unittest.TestCase):
 
 	def test_load_config(self):
-		nielsen.load_config('nielsen.ini')
+		loaded = nielsen.load_config('nielsen.ini')
+		self.assertEqual(loaded, ['nielsen.ini'])
 		self.assertEqual(nielsen.CONFIG['Options']['LogFile'], '/var/log/nielsen.log')
 
 


### PR DESCRIPTION
- Add `update_imdb_ids` to `config.py`.  and `__init__.py`.
- Use `get` and `set` more consistently when dealing with the config.
- After processing files, reload the config and then write it.
- Improve `load_config` test slightly.
- Add `tags` file to `.gitignore`.
- Remove `pyxdg` requirement.
- Bump version.
- Resolves #46.