### PR TITLE
Catch exceptions when web-services fail

### DIFF
--- a/nielsen/__init__.py
+++ b/nielsen/__init__.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
-'''Mark this as a package.'''
+'''
+chown, chmod, rename, and organize TV show files.
+'''
 
 from .api import (
 	filter_series,

--- a/nielsen/api.py
+++ b/nielsen/api.py
@@ -27,7 +27,6 @@ def get_file_info(filename):
 		The Glades -201- Family Matters.avi
 		Bones.S04E01E02.720p.HDTV.X264-DIMENSION.mkv
 	"""
-
 	patterns = [
 		# The.Flash.2014.217.Flash.Back.HDTV.x264-LOL[ettv].mp4
 		re.compile(r"(?P<series>.+)\.+(?P<year>\d{4})\.(?P<season>\d{1,2})(?P<episode>\d{2})\.*(?P<title>.*)?\.+(?P<extension>\w+)$", re.IGNORECASE),
@@ -155,7 +154,7 @@ def process_file(filename):
 
 		if CONFIG.get('Options', 'Mode'):
 			try:
-				chmod(filename, int(CONFIG.getint('Options', 'Mode'), 8))
+				chmod(filename, int(CONFIG.get('Options', 'Mode'), 8))
 			except PermissionError as err:
 				logging.error("chmod failed. {0}".format(err))
 
@@ -183,6 +182,8 @@ def process_file(filename):
 
 
 def main():
+	'''Handle command line arguments and run all files through the process_file
+	function.'''
 	# Command line arguments
 	PARSER = argparse.ArgumentParser(description=
 		"Process episodes of TV shows for storage on a media server.")

--- a/nielsen/titles.py
+++ b/nielsen/titles.py
@@ -19,7 +19,10 @@ def get_imdb_id(series):
 		imdb_id = CONFIG['IMDB'][series]
 	else:
 		# Search IMDB for series
-		results = omdb.search_series(series)
+		try:
+			results = omdb.search_series(series)
+		except:
+			logging.error("Unable to retrieve series names.")
 
 		if len(results) == 1:
 			# If only one result, use it
@@ -38,6 +41,8 @@ def get_imdb_id(series):
 			except (ValueError, IndexError, EOFError) as e:
 				logging.error("Caught exception: {0}".format(e))
 				return None
+		else:
+			imdb_id = None
 
 	logging.info("IMDB ID for '{0}': {1}".format(series, imdb_id))
 	# Add whatever we find or select back to the config
@@ -55,8 +60,12 @@ def get_episode_title(season, episode, imdb_id=None, series=None):
 	if imdb_id:
 		logging.info("IMDB ID: {0}, Season: {1}, Episode: {2}".format(imdb_id,
 			season, episode))
-		return omdb.imdbid(imdb_id, season=season, episode=episode)['title']
-	else:
-		return None
+		try:
+			return omdb.imdbid(imdb_id, season=season, episode=episode)['title']
+		except:
+			logging.error("Unable to retrieve episode title.")
+
+	# If all else fails, return an empty string, not None
+	return str()
 
 # vim: tabstop=4 softtabstop=4 shiftwidth=4 noexpandtab

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup
 
 setup(
 	name='Nielsen',
-	version='0.9.6',
+	version='0.9.7',
 	author="Michael 'Irish' O'Neill",
 	author_email="irish.dot@gmail.com",
 	url='https://github.com/IrishPrime/nielsen/',


### PR DESCRIPTION
- Catch exceptions when attempting to retrieve series or episode names.
- Remove pointless cast of `int` to `int`.
- Resolves #49.