### PR TITLE
Add TVmaze support, remove omdb

### DIFF
--- a/nielsen.ini
+++ b/nielsen.ini
@@ -6,14 +6,18 @@ LogFile = /var/log/nielsen.log
 LogLevel = DEBUG
 MediaPath = /home/irish/Videos/TV/
 OrganizeFiles = True
-IMDB = False
+DryRun = False
+FetchTitles = False
+ServiceURI = http://api.tvmaze.com/
 
 [Filters]
-Archer 2009 = Archer
+Agents of S.H.I.E.L.D. = Agents of SHIELD
 Archer (2009) = Archer
+Archer 2009 = Archer
 Castle (2009) = Castle
 DC's Legends of Tomorrow = Legends of Tomorrow
 DCs Legends of Tomorrow = Legends of Tomorrow
+Dirk Gentlys Holistic Detective Agency = Dirk Gently's Holistic Detective Agency
 Game Of Thrones = Game of Thrones
 It's Always Sunny In Philadelphia = It's Always Sunny in Philadelphia
 Its Always Sunny In Philadelphia = It's Always Sunny in Philadelphia
@@ -24,7 +28,20 @@ Person Of Interest = Person of Interest
 The Flash (2014) = The Flash
 The Flash 2014 = The Flash
 
-[IMDB]
-Agents of SHIELD = tt2364582
-Archer = tt1486217
-Castle = tt1219024
+[IDs]
+Agents of SHIELD = 31
+American Gods = 3182
+Archer = 315
+Arrow = 4
+Castle = 68
+Dirk Gently's Holistic Detective Agency = 11405
+Game of Thrones = 82
+House = 118
+Legends of Tomorrow = 1851
+Legion = 6393
+Lucifer = 1859
+Preacher = 3144
+Supernatural = 19
+The Flash = 13
+Top Gear = 522
+Westworld = 1371

--- a/nielsen/__init__.py
+++ b/nielsen/__init__.py
@@ -13,12 +13,12 @@ from .api import (
 from .config import (
 	CONFIG,
 	load_config,
-	update_imdb_ids,
+	update_series_ids,
 )
 
 from .titles import (
 	get_episode_title,
-	get_imdb_id,
+	get_series_id,
 )
 
 __all__ = ['api', 'titles', 'config']

--- a/nielsen/api.py
+++ b/nielsen/api.py
@@ -6,7 +6,7 @@ import argparse
 import logging
 import re
 from .titles import get_episode_title
-from .config import CONFIG, load_config, update_imdb_ids
+from .config import CONFIG, load_config, update_series_ids
 from os import chmod, makedirs, name, path, rename
 from shutil import chown, move
 
@@ -64,8 +64,8 @@ def get_file_info(filename):
 			if info['title'].islower():
 				# Use title case if everything is lowercase
 				info['title'] = info['title'].title()
-			elif not info['title'] and CONFIG.getboolean('Options', 'IMDB'):
-				# If no title, fetch from IMDB
+			elif not info['title'] and CONFIG.getboolean('Options', 'FetchTitles'):
+				# If no title, fetch from web
 				info['title'] = get_episode_title(
 					info['season'], info['episode'], series=info['series'])
 
@@ -197,11 +197,11 @@ def main():
 	PARSER.add_argument("--no-organize", dest="organize", action="store_false",
 		help="Do not organize files")
 	PARSER.set_defaults(organize=None)
-	PARSER.add_argument("-i", "--imdb", dest="imdb", action="store_true",
-		help="Fetch titles from IMDB")
-	PARSER.add_argument("--no-imdb", dest="imdb", action="store_false",
-		help="Do not fetch titles from IMDB")
-	PARSER.set_defaults(imdb=None)
+	PARSER.add_argument("-f", "--fetch", dest="fetch", action="store_true",
+		help="Fetch titles from the web")
+	PARSER.add_argument("--no-fetch", dest="fetch", action="store_false",
+		help="Do not fetch titles from the web")
+	PARSER.set_defaults(fetch=None)
 	PARSER.add_argument("-n", "--dry-run", dest="dry_run", action="store_true",
 		help="Do not rename files, just list the renaming actions.")
 	PARSER.set_defaults(dry_run=False)
@@ -229,8 +229,8 @@ def main():
 	if ARGS.organize is not None:
 		CONFIG.set('Options', 'OrganizeFiles', ARGS.organize)
 
-	if ARGS.imdb is not None:
-		CONFIG.set('Options', 'IMDB', ARGS.imdb)
+	if ARGS.fetch is not None:
+		CONFIG.set('Options', 'FetchTitles', ARGS.fetch)
 
 	if ARGS.dry_run is not False:
 		CONFIG.set('Options', 'DryRun', ARGS.dry_run)
@@ -252,8 +252,8 @@ def main():
 	for f in ARGS.files:
 		process_file(f)
 
-	# Add IMDB IDs to config file
-	update_imdb_ids(ARGS.config_file)
+	# Add series IDs to config file
+	update_series_ids(ARGS.config_file)
 
 
 if __name__ == "__main__":

--- a/nielsen/config.py
+++ b/nielsen/config.py
@@ -10,7 +10,7 @@ from os import getenv, name, path
 CONFIG = configparser.ConfigParser()
 CONFIG.add_section('Options')
 CONFIG.add_section('Filters')
-CONFIG.add_section('IMDB')
+CONFIG.add_section('IDs')
 CONFIG['Options'] = {
 	'User': '',
 	'Group': '',
@@ -20,7 +20,8 @@ CONFIG['Options'] = {
 	'MediaPath': '',
 	'OrganizeFiles': 'False',
 	'DryRun': 'False',
-	'IMDB': 'False',
+	'FetchTitles': 'False',
+	'ServiceURI': 'http://api.tvmaze.com/',
 }
 
 
@@ -40,14 +41,15 @@ def load_config(file_name=None):
 	return CONFIG.read(config_file)
 
 
-def update_imdb_ids(file_name=None):
-	"""Add imdb_ids to IMDB section of file_name or default user file."""
+def update_series_ids(file_name=None):
+	"""Add series_ids to IDs section of file_name or default user file."""
 	# Reloading the config will overwrite existing options from filename, but
-	# will not unset newly added options, so the IMDB section should be
-	# unaffected.
+	# will not unset newly added options, so the IDs section should be
+	# unaffected by said reload.
 	config_files = load_config(file_name)
 	file_name = config_files[-1]
 	with open(file_name, 'w') as f:
 		CONFIG.write(f)
+
 
 # vim: tabstop=4 softtabstop=4 shiftwidth=4 noexpandtab

--- a/nielsen/titles.py
+++ b/nielsen/titles.py
@@ -1,71 +1,80 @@
 #!/usr/bin/env python3
-"""
+'''
 Episode title module for Nielsen.
-Fetches information from IMDB through the omdb module.
-"""
+Fetches information from TVmaze.
+'''
 
 import logging
-import omdb
+import requests
 from .config import CONFIG
 
 
-def get_imdb_id(series):
-	"""Return the IMDB ID of a given series.
-	If an ID isn't found in the config, search IMDB and allow the user to
-	select a match."""
-
-	if CONFIG.has_option('IMDB', series):
-		# Check config for IMDB ID
-		imdb_id = CONFIG['IMDB'][series]
+def get_series_id(series):
+	'''Return a unique ID for a given series.
+	If an ID isn't found in the config, allow the user to select a match from
+	search results.'''
+	if CONFIG.has_option('IDs', series):
+		# Check config for series ID
+		series_id = CONFIG['IDs'][series]
 	else:
-		# Search IMDB for series
+		# Search for the series
 		try:
-			results = omdb.search_series(series)
+			r = requests.get('{0}search/shows?q={1}'.
+				format(CONFIG['Options']['ServiceURI'], series))
 		except:
-			logging.error("Unable to retrieve series names.")
+			logging.error('Unable to retrieve series names.')
+
+		# Get search results as JSON
+		results = r.json()
 
 		if len(results) == 1:
 			# If only one result, use it
-			imdb_id = results[0]['imdb_id']
+			series_id = results[0]['show']['id']
 		elif len(results) > 1:
-			# If multiple results, select one
+			# If multiple results, display them for selection
 			print("Search results for '{0}'".format(series))
 			for i, result in enumerate(results):
-				print("{0}. {1} ({2}) - {3}".format(i, result['title'],
-					result['year'], result['imdb_id']))
-			print("Other input cancels without selection.")
-
+				print('{0}. {1} ({2}) - {3}'.format(i, result['show']['name'],
+					result['show']['premiered'], result['show']['id']))
+			print('Other input cancels without selection.')
 			try:
-				selection = int(input("Select series: "))
-				imdb_id = results[int(selection)]['imdb_id']
+				selection = int(input('Select series: '))
+				series_id = results[int(selection)]['show']['id']
 			except (ValueError, IndexError, EOFError) as e:
-				logging.error("Caught exception: {0}".format(e))
+				logging.error('Caught exception: {0}'.format(e))
 				return None
 		else:
-			imdb_id = None
+			# No results
+			series_id = None
 
-	logging.info("IMDB ID for '{0}': {1}".format(series, imdb_id))
+	logging.info("Show ID for '{0}': {1}".format(series, series_id))
+
 	# Add whatever we find or select back to the config
-	CONFIG.set('IMDB', series, imdb_id)
+	CONFIG.set('IDs', series, str(series_id))
 
-	return imdb_id
+	return series_id
 
 
-def get_episode_title(season, episode, imdb_id=None, series=None):
-	"""Return the episode title using the series name or IMDB ID, season, and
-	episode number."""
-	if imdb_id is None and series:
-		imdb_id = get_imdb_id(series)
+def get_episode_title(season, episode, series_id=None, series=None):
+	'''Return the episode title using the series name or ID, season, and
+	episode number.'''
+	if series_id is None and series:
+		series_id = get_series_id(series)
 
-	if imdb_id:
-		logging.info("IMDB ID: {0}, Season: {1}, Episode: {2}".format(imdb_id,
+	if series_id:
+		logging.info('Series ID: {0}, Season: {1}, Episode: {2}'.format(series_id,
 			season, episode))
 		try:
-			return omdb.imdbid(imdb_id, season=season, episode=episode)['title']
+			r = requests.get('{0}shows/{1}/episodebynumber?season={2}&number={3}'
+					.format(CONFIG['Options']['ServiceURI'], series_id, season, episode))
+			title = r.json()['name']
+			logging.info('Title: {}'.format(title))
+			return title
 		except:
-			logging.error("Unable to retrieve episode title.")
+			logging.error('Unable to retrieve episode title.')
 
 	# If all else fails, return an empty string, not None
 	return str()
+
 
 # vim: tabstop=4 softtabstop=4 shiftwidth=4 noexpandtab

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup
 
 setup(
 	name='Nielsen',
-	version='0.9.7',
+	version='1.0.0',
 	author="Michael 'Irish' O'Neill",
 	author_email="irish.dot@gmail.com",
 	url='https://github.com/IrishPrime/nielsen/',
@@ -27,7 +27,7 @@ setup(
 		'Topic :: Desktop Environment :: File Managers',
 		'Topic :: Multimedia :: Video',
 	],
-	install_requires=['omdb'],
+	install_requires=['requests'],
 	entry_points={
 		'console_scripts': ['nielsen=nielsen.api:main'],
 	},

--- a/test.py
+++ b/test.py
@@ -4,6 +4,9 @@
 import unittest
 import nielsen
 
+# Ensure config is loaded regardless of test order
+nielsen.load_config('nielsen.ini')
+
 
 class TestConfig(unittest.TestCase):
 
@@ -13,7 +16,7 @@ class TestConfig(unittest.TestCase):
 		self.assertEqual(nielsen.CONFIG['Options']['LogFile'], '/var/log/nielsen.log')
 
 
-class TestNielsen(unittest.TestCase):
+class TestAPI(unittest.TestCase):
 
 	def test_get_file_info(self):
 		file_names = {
@@ -38,7 +41,7 @@ class TestNielsen(unittest.TestCase):
 				"extension": "avi"
 			},
 
-			# Missing Title
+			# Missing title
 			"The.Glades.S02E01.HDTV.XviD-FQM.avi": {
 				"series": "The Glades",
 				"season": "02",
@@ -197,24 +200,46 @@ class TestNielsen(unittest.TestCase):
 
 	def test_filter_series(self):
 		self.assertEqual(nielsen.filter_series("Castle (2009)"), "Castle")
-		self.assertEqual(nielsen.filter_series("Dc'S Legends Of Tomorrow"), "Legends of Tomorrow")
+		self.assertEqual(nielsen.filter_series("Dc'S Legends Of Tomorrow"),
+			"Legends of Tomorrow")
 		self.assertEqual(nielsen.filter_series("Game Of Thrones"), "Game of Thrones")
-		self.assertEqual(nielsen.filter_series("It's Always Sunny In Philadelphia"), "It's Always Sunny in Philadelphia")
-		self.assertEqual(nielsen.filter_series("Its Always Sunny In Philadelphia"), "It's Always Sunny in Philadelphia")
+		self.assertEqual(nielsen.filter_series("It's Always Sunny In Philadelphia"),
+			"It's Always Sunny in Philadelphia")
+		self.assertEqual(nielsen.filter_series("Its Always Sunny In Philadelphia"),
+			"It's Always Sunny in Philadelphia")
 		self.assertEqual(nielsen.filter_series("Mr Robot"), "Mr. Robot")
-		self.assertEqual(nielsen.filter_series("Person Of Interest"), "Person of Interest")
+		self.assertEqual(nielsen.filter_series("Person Of Interest"),
+			"Person of Interest")
 		self.assertEqual(nielsen.filter_series("The Flash (2014)"), "The Flash")
 		self.assertEqual(nielsen.filter_series("The Flash 2014"), "The Flash")
 
 
 class TestTitles(unittest.TestCase):
 
-	def test_get_imdb_id(self):
-		self.assertEqual(nielsen.get_imdb_id('Agents of SHIELD'), 'tt2364582')
+	def test_get_series_id(self):
+		self.assertEqual(nielsen.get_series_id('Agents of SHIELD'), '31')
+		self.assertEqual(nielsen.get_series_id('American Gods'), '3182')
+		self.assertEqual(nielsen.get_series_id('Archer'), '315')
+		self.assertEqual(nielsen.get_series_id('Arrow'), '4')
+		self.assertEqual(nielsen.get_series_id('Castle'), '68')
+		self.assertEqual(nielsen.get_series_id(
+			'Dirk Gently\'s Holistic Detective Agency'), '11405')
+		self.assertEqual(nielsen.get_series_id('Game of Thrones'), '82')
+		self.assertEqual(nielsen.get_series_id('House'), '118')
+		self.assertEqual(nielsen.get_series_id('Legends of Tomorrow'), '1851')
+		self.assertEqual(nielsen.get_series_id('Legion'), '6393')
+		self.assertEqual(nielsen.get_series_id('Lucifer'), '1859')
+		self.assertEqual(nielsen.get_series_id('Preacher'), '3144')
+		self.assertEqual(nielsen.get_series_id('Supernatural'), '19')
+		self.assertEqual(nielsen.get_series_id('The Flash'), '13')
+		self.assertEqual(nielsen.get_series_id('Top Gear'), '522')
+		self.assertEqual(nielsen.get_series_id('Westworld'), '1371')
 
 	def test_get_episode_title(self):
-		self.assertEqual(nielsen.get_episode_title(1, 12, imdb_id='tt4532368'), 'Last Refuge')
-		self.assertEqual(nielsen.get_episode_title(4, 2, series='Castle'), 'Heroes and Villains')
+		self.assertEqual(nielsen.get_episode_title(1, 12, series_id='1851'),
+			'Last Refuge')
+		self.assertEqual(nielsen.get_episode_title(4, 3, series='Castle'),
+			'Head Case')
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- Remove all references to `omdb`. The `omdb` API is no longer free, and
  is therefore no longer a good option for this project.
- Remove all references to IMDB. TVmaze is now used in its place.
- Add `requests` as a project dependency.
- Add new options to the default configuration file (`nielsen.ini`).
- Replace `--imdb` command line option with `--fetch`.
- Test more series in `get_series_id`.
- Bump version to 1.0.0.
- Resolves #50.