### PR TITLE
Improve handling of boolean command line options

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ python:
   - "3.3"
   - "3.4"
   - "3.5"
+  - "3.6"
   - "nightly"
 # command to install dependencies
 install:

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup
 
 setup(
 	name='Nielsen',
-	version='1.0.0',
+	version='1.0.1',
 	author="Michael 'Irish' O'Neill",
 	author_email="irish.dot@gmail.com",
 	url='https://github.com/IrishPrime/nielsen/',
@@ -23,6 +23,7 @@ setup(
 		'Programming Language :: Python :: 3.3',
 		'Programming Language :: Python :: 3.4',
 		'Programming Language :: Python :: 3.5',
+		'Programming Language :: Python :: 3.6',
 		'Programming Language :: Python',
 		'Topic :: Desktop Environment :: File Managers',
 		'Topic :: Multimedia :: Video',


### PR DESCRIPTION
- Store the string values `'True'` and `'False'` for option flag type
  command line arguments rather than actual boolean values. These values
  are passed to the `configparser`, which only accepts strings. This
  affects `--[no-]organize`, `--[no-]fetch`, and `--dry-run`.
- Create mutually exclusive option groups for the option flag type
  command line arguments so users cannot pass, for example,
  `--fetch --no-fetch`.
- Add comments to help break up the wall of `argparse` code.
- List Python 3.6 as a valid version in `setup.py`.
- Resolves #53.