### PR TITLE
Strip parent directory from filename when moving files

### DIFF
--- a/nielsen/api.py
+++ b/nielsen/api.py
@@ -8,7 +8,7 @@ import re
 from .titles import get_episode_title
 from .config import CONFIG, load_config, update_series_ids
 from os import chmod, makedirs, name, path, rename
-from shutil import chown, move
+from shutil import chown
 
 
 def get_file_info(filename):
@@ -97,14 +97,15 @@ def organize_file(filename, series, season):
 		logging.debug("Creating and/or moving to: {0}".format(new_path))
 		makedirs(new_path, exist_ok=True)
 
-		dst = path.join(new_path, filename)
+		dst = path.join(new_path, path.basename(filename))
 
 		# Do not attempt to overwrite existing files
 		if path.isfile(dst):
 			logging.warning("{0} already exists. File will not be moved.".format(dst))
 		else:
 			try:
-				move(filename, dst)
+				logging.info("Moved to {0}".format(dst))
+				rename(filename, dst)
 			except Exception as err:
 				logging.error(err)
 
@@ -168,10 +169,10 @@ def process_file(filename):
 			info['extension'])
 		logging.info("Rename to: '{0}'".format(clean))
 
-		# Get the base directory of the file so the rename operation doesn't
+		# Get the parent directory of the file so the rename operation doesn't
 		# move it unintentionally
-		base = path.dirname(filename)
-		clean = path.join(base, clean)
+		parent = path.dirname(filename)
+		clean = path.join(parent, clean)
 
 		if CONFIG.getboolean('Options', 'DryRun'):
 			print(filename + " → " + clean)

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup
 
 setup(
 	name='Nielsen',
-	version='1.0.2',
+	version='1.0.3',
 	author="Michael 'Irish' O'Neill",
 	author_email="irish.dot@gmail.com",
 	url='https://github.com/IrishPrime/nielsen/',

--- a/test.py
+++ b/test.py
@@ -176,6 +176,15 @@ class TestAPI(unittest.TestCase):
 				"extension": "mkv"
 			},
 
+			# File in a subdirectory
+			"Game.of.Thrones.S07E01.720p.HDTV.x264-AVS[rarbg]/Game.of.Thrones.S07E01.720p.HDTV.x264-AVS.mkv": {
+				"series": "Game of Thrones",
+				"season": "07",
+				"episode": "01",
+				"title": "Dragonstone",
+				"extension": "mkv"
+			},
+
 			# Multi-episode file
 			"Bones.S04E01E02.720p.HDTV.X264-DIMENSION.mkv": {
 				"series": "Bones",


### PR DESCRIPTION
- Use only the `basename` portion of the `filename` argument when
  setting the destination path for an episode in `organize_file`.
- Add a test to `get_file_info` for files in a subdirectory.
- Resolves #57.