### PR TITLE
Add "last ditch effort" pattern

### DIFF
--- a/nielsen.ini
+++ b/nielsen.ini
@@ -39,6 +39,7 @@ Game of Thrones = 82
 House = 118
 Legends of Tomorrow = 1851
 Legion = 6393
+Limitless = 2473
 Lucifer = 1859
 Preacher = 3144
 Supernatural = 19

--- a/nielsen/titles.py
+++ b/nielsen/titles.py
@@ -19,13 +19,13 @@ def get_series_id(series):
 	else:
 		# Search for the series
 		try:
-			r = requests.get('{0}search/shows?q={1}'.
+			response = requests.get('{0}search/shows?q={1}'.
 				format(CONFIG['Options']['ServiceURI'], series))
 		except:
 			logging.error('Unable to retrieve series names.')
 
 		# Get search results as JSON
-		results = r.json()
+		results = response.json()
 
 		if len(results) == 1:
 			# If only one result, use it
@@ -41,13 +41,13 @@ def get_series_id(series):
 				selection = int(input('Select series: '))
 				series_id = results[int(selection)]['show']['id']
 			except (ValueError, IndexError, EOFError) as e:
-				logging.error('Caught exception: {0}'.format(e))
+				logging.error('Caught exception: %s', e)
 				return None
 		else:
 			# No results
 			series_id = None
 
-	logging.info("Show ID for '{0}': {1}".format(series, series_id))
+	logging.info("Show ID for '%s': %s", series, series_id)
 
 	# Add whatever we find or select back to the config
 	CONFIG.set('IDs', series, str(series_id))
@@ -62,13 +62,13 @@ def get_episode_title(season, episode, series_id=None, series=None):
 		series_id = get_series_id(series)
 
 	if series_id:
-		logging.info('Series ID: {0}, Season: {1}, Episode: {2}'.format(series_id,
-			season, episode))
+		logging.info('Series ID: %s, Season: %s, Episode: %s', series_id,
+				season, episode)
 		try:
-			r = requests.get('{0}shows/{1}/episodebynumber?season={2}&number={3}'
+			response = requests.get('{0}shows/{1}/episodebynumber?season={2}&number={3}'
 					.format(CONFIG['Options']['ServiceURI'], series_id, season, episode))
-			title = r.json()['name']
-			logging.info('Title: {}'.format(title))
+			title = response.json()['name']
+			logging.info('Title: %s', title)
 			return title
 		except:
 			logging.error('Unable to retrieve episode title.')

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup
 
 setup(
 	name='Nielsen',
-	version='1.0.3',
+	version='1.1.0',
 	author="Michael 'Irish' O'Neill",
 	author_email="irish.dot@gmail.com",
 	url='https://github.com/IrishPrime/nielsen/',

--- a/test.py
+++ b/test.py
@@ -161,6 +161,7 @@ class TestAPI(unittest.TestCase):
 			# Four digit year followed by three digit season and episode combination
 			"The.Flash.2014.217.Flash.Back.HDTV.x264-LOL[ettv].mp4": {
 				"series": "The Flash",
+				"year": "2014",
 				"season": "02",
 				"episode": "17",
 				"title": "Flash Back",
@@ -200,6 +201,15 @@ class TestAPI(unittest.TestCase):
 				"season": "01",
 				"episode": "01",
 				"title": "E19 Protocol",
+				"extension": "mkv"
+			},
+
+			# Unusual filename for last ditch effort pattern
+			"Limitless S01E11 This Is Your Brian on Drugs (1080p x265 Joy).mkv": {
+				"series": "Limitless",
+				"season": "01",
+				"episode": "11",
+				"title": "This is Your Brian on Drugs",
 				"extension": "mkv"
 			},
 		}


### PR DESCRIPTION
- Add a pattern which attempts to recognize a series name, season, and
  episode number without much structure in the format beyond that order.
  With those three pieces of information, the title can be fetched. Note
  to self, this is probably how the project should have started.
- Add a test case for the new pattern.
- Add the series ID for "Limitless" since it's used in the new test.
- Use the `groupdict` function to build the file information dictionary
  in a somewhat more automatic way.
- Address some standards failings and linting issues (namely, overly
  terse variable names and string interpolation for log messages).
- Bump the minor version number.
- Resolves #60.