### PR TITLE
Replace invalid filename characters with hyphens

### DIFF
--- a/nielsen/__init__.py
+++ b/nielsen/__init__.py
@@ -4,6 +4,7 @@ chown, chmod, rename, and organize TV show files.
 '''
 
 from .api import (
+	filter_filename,
 	filter_series,
 	get_file_info,
 	organize_file,

--- a/nielsen/config.py
+++ b/nielsen/config.py
@@ -25,11 +25,11 @@ CONFIG['Options'] = {
 }
 
 
-def load_config(file_name=None):
-	'''Load config file specified by file_name, or check XDG directories for
+def load_config(filename=None):
+	'''Load config file specified by filename, or check XDG directories for
 	configuration file.'''
-	if file_name and path.isfile(file_name):
-		config_file = file_name
+	if filename and path.isfile(filename):
+		config_file = filename
 	else:
 		if name == "posix":
 			config_file = ["/etc/xdg/nielsen/nielsen.ini",
@@ -41,14 +41,14 @@ def load_config(file_name=None):
 	return CONFIG.read(config_file)
 
 
-def update_series_ids(file_name=None):
-	'''Add series_ids to IDs section of file_name or default user file.'''
-	# Reloading the config will overwrite existing options from file_name, but
+def update_series_ids(filename=None):
+	'''Add series_ids to IDs section of filename or default user file.'''
+	# Reloading the config will overwrite existing options from filename, but
 	# will not unset newly added options, so the IDs section should be
 	# unaffected by said reload.
-	config_files = load_config(file_name)
-	file_name = config_files[-1]
-	with open(file_name, 'w') as f:
+	config_files = load_config(filename)
+	filename = config_files[-1]
+	with open(filename, 'w') as f:
 		CONFIG.write(f)
 
 

--- a/test.py
+++ b/test.py
@@ -2,6 +2,7 @@
 '''Test cases for Nielsen.'''
 
 import unittest
+from unittest.mock import patch
 import nielsen
 
 # Ensure config is loaded regardless of test order
@@ -19,11 +20,11 @@ class TestConfig(unittest.TestCase):
 
 
 class TestAPI(unittest.TestCase):
-	'''Tests for the core functionality'''
+	'''Tests for the core functionality.'''
 
 	def test_get_file_info(self):
-		'''Get info from sample files and compare to expected output'''
-		file_names = {
+		'''Get info from sample files and compare to expected output.'''
+		filenames = {
 			"Something.Close.12.mp4":
 			None,
 
@@ -218,11 +219,11 @@ class TestAPI(unittest.TestCase):
 			},
 		}
 
-		for path, info in file_names.items():
+		for path, info in filenames.items():
 			self.assertEqual(nielsen.get_file_info(path), info)
 
 	def test_filter_series(self):
-		'''Test mapping series to a preferred name'''
+		'''Test mapping series to a preferred name.'''
 		self.assertEqual(nielsen.filter_series("Castle (2009)"), "Castle")
 		self.assertEqual(nielsen.filter_series("Dc'S Legends Of Tomorrow"),
 			"Legends of Tomorrow")
@@ -236,6 +237,13 @@ class TestAPI(unittest.TestCase):
 			"Person of Interest")
 		self.assertEqual(nielsen.filter_series("The Flash (2014)"), "The Flash")
 		self.assertEqual(nielsen.filter_series("The Flash 2014"), "The Flash")
+
+	def test_filter_filename(self):
+		'''Test removing invalid characters from filenames.'''
+		# Invalid characters for POSIX systems
+		self.assertEqual(nielsen.filter_filename(
+			'Brooklyn Nine-Nine -02.20- AC/DC.mp4'),
+			'Brooklyn Nine-Nine -02.20- AC-DC.mp4')
 
 
 class TestTitles(unittest.TestCase):


### PR DESCRIPTION
- Add `nielsen.filter_filename()` to replace any characters which cannot
  appear in a filename (based on the operating system) with hyphens.
- Add a test for `nielsen.filter_filename()`.
- Replace instances of `file_name` with `filename` for consistency.
- Use quotes more consistently throughout.
- Resolves #59.