### PR TITLE
Use pathlib for handling file paths and manipulation

### DIFF
--- a/nielsen/__init__.py
+++ b/nielsen/__init__.py
@@ -17,6 +17,6 @@ from nielsen.config import (
 	update_series_ids,
 )
 
-__all__ = ['api', 'tv', 'config']
+__all__ = ['api', 'config', 'files', 'tv']
 
 # vim: tabstop=4 softtabstop=4 shiftwidth=4 noexpandtab

--- a/nielsen/files.py
+++ b/nielsen/files.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+
+'''
+System-level file operations needed by the API. These functions operate on the
+various Path class objects provided by the pathlib library. These functions
+probably won't ever need to be called directly by a client.
+'''
+
+import logging
+from shutil import chown, move as su_move
+from nielsen.config import CONFIG
+
+
+def set_file_mode(file):
+	'''Set the mode of `file` to the value defined in `CONFIG`.'''
+	if CONFIG.get('Options', 'Mode'):
+		try:
+			file.chmod(int(CONFIG.get('Options', 'Mode'), 8))
+		except PermissionError as err:
+			logging.error("chmod failed. %s", err)
+			raise
+
+
+def set_file_ownership(file):
+	'''Set owner and group of `file` to the values defined in `CONFIG`.'''
+	if (CONFIG.get('Options', 'User') or CONFIG.get('Options', 'Group')):
+		try:
+			chown(file, CONFIG.get('Options', 'User') or None,
+				CONFIG.get('Options', 'Group') or None)
+			status = True
+		except PermissionError as err:
+			logging.error("chown failed. %s", err)
+			raise
+
+
+def create_hierarchy(file):
+	'''Create the directory hierarchy for the given `file`.'''
+	try:
+		# Create the parent directories of the file path if they don't exist
+		file.parent.mkdir(mode=int(CONFIG.get('Options', 'mode'), 8),
+				parents=True, exist_ok=True)
+		logging.debug('Created: %s', file.parent)
+		status = True
+	except FileExistsError:
+		logging.debug('%s already exists', file.parent)
+	except PermissionError as err:
+		logging.error(err)
+		raise
+
+
+def move(src, dst):
+	'''Move the file `src` to the path `dst`, but do not overwrite existing files.'''
+	if dst.exists() or src == dst:
+		# If the destination file already exists, or the source and destination
+		# point to the same path, take no further actions
+		logging.debug('%s already in MediaPath. File will not be moved.', dst)
+
+	try:
+		su_move(src, dst)
+	except PermissionError as err:
+		logging.error(err)
+		raise
+
+
+# vim: tabstop=4 softtabstop=4 shiftwidth=4 noexpandtab

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup
 
 setup(
 	name='Nielsen',
-	version='2.0.0',
+	version='2.1.0',
 	author="Michael 'Irish' O'Neill",
 	author_email="irish.dot@gmail.com",
 	url='https://github.com/IrishPrime/nielsen/',

--- a/test.py
+++ b/test.py
@@ -222,6 +222,7 @@ class TestAPI(unittest.TestCase):
 		for path, info in filenames.items():
 			self.assertEqual(nielsen.get_file_info(path), info)
 
+
 	def test_filter_series(self):
 		'''Test mapping series to a preferred name.'''
 		self.assertEqual(nielsen.filter_series("Castle (2009)"), "Castle")
@@ -237,6 +238,7 @@ class TestAPI(unittest.TestCase):
 			"Person of Interest")
 		self.assertEqual(nielsen.filter_series("The Flash (2014)"), "The Flash")
 		self.assertEqual(nielsen.filter_series("The Flash 2014"), "The Flash")
+
 
 	def test_filter_filename(self):
 		'''Test removing invalid characters from filenames.'''
@@ -292,5 +294,6 @@ class TestTV(unittest.TestCase):
 
 if __name__ == '__main__':
 	unittest.main()
+
 
 # vim: tabstop=4 softtabstop=4 shiftwidth=4 noexpandtab


### PR DESCRIPTION
Add support for `pathlib` and use it to handle generating file paths
and extracting information from them rather than `os.path`.

Add a `nielsen.files` module which handles most of the underlying file
operations (making calls out to `shutil` for things like `chown` and
`move`). This abstraction allows not only for more reusable code, but
smaller functions to test and removes the overhead of a lot of context
for the API level functions (most notably `organize_file`).

Favor returning `Path` objects from API functions that modify files in
some way. Returning the most up-to-date version of the `Path` object
allows the API to be more composable and extendable.

Use an intermediate value for defining the filename format for processed
files. This opens up possibilities for customization.

Resolves #71.

Resolves #73.