### PR TITLE
Remove millisecond level logging

### DIFF
--- a/bin/cli.py
+++ b/bin/cli.py
@@ -95,7 +95,7 @@ def main():
 
 	# Configure logging
 	logging.basicConfig(filename=nielsen.config.CONFIG.get('Options', 'LogFile'),
-		format='%(asctime)-15s %(levelname)-8s %(message)s',
+		format='%(asctime)s %(levelname)-8s %(message)s', datefmt='%Y-%m-%d %H:%M:%S',
 		level=getattr(logging, nielsen.config.CONFIG.get('Options', 'LogLevel'), 30))
 
 	# Log all configuration options

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup
 
 setup(
 	name='Nielsen',
-	version='2.1.0',
+	version='2.1.1',
 	author="Michael 'Irish' O'Neill",
 	author_email="irish.dot@gmail.com",
 	url='https://github.com/IrishPrime/nielsen/',


### PR DESCRIPTION
Change the date format to only log at one-second precision. Millisecond
level precision is not required for this type of application and just
makes logs more annoying to read.

Bump version to `2.1.1`.