### PR TITLE
Check for the true case rather than false

### DIFF
--- a/nielsen/tv.py
+++ b/nielsen/tv.py
@@ -59,12 +59,12 @@ def get_series_id(series, interactive=CONFIG.get('Options', 'Interactive')):
 
 		if response.status_code == 200:
 			# Only check successful responses
-			if not interactive:
-				# The results are structured differently in non-interactive mode
-				series_id = results['id']
-			else:
+			if interactive:
 				# Interactive selection if required
 				series_id = select_series(series, results)
+			else:
+				# The results are structured differently in non-interactive mode
+				series_id = results['id']
 
 	logging.info("Show ID for '%s': %s", series, series_id)
 


### PR DESCRIPTION
Check for the true case in `if` statements rather than the false case
when both are going to result in execution anyway. Inverting the logic
just makes it difficult for people to read.