### PR TITLE
Rename `filter_filename` to `sanitize_filename`

### DIFF
--- a/nielsen/__init__.py
+++ b/nielsen/__init__.py
@@ -4,11 +4,11 @@ chown, chmod, rename, and organize TV show files.
 '''
 
 from nielsen.api import (
-	filter_filename,
 	filter_series,
 	get_file_info,
 	organize_file,
 	process_file,
+	sanitize_filename,
 )
 
 from nielsen.config import (

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup
 
 setup(
 	name='Nielsen',
-	version='2.1.1',
+	version='2.1.3',
 	author="Michael 'Irish' O'Neill",
 	author_email="irish.dot@gmail.com",
 	url='https://github.com/IrishPrime/nielsen/',
@@ -20,11 +20,9 @@ setup(
 		'License :: OSI Approved :: GNU General Public License v3 (GPLv3)',
 		'Operating System :: Microsoft :: Windows',
 		'Operating System :: POSIX :: Linux',
-		'Programming Language :: Python :: 3.3',
-		'Programming Language :: Python :: 3.4',
-		'Programming Language :: Python :: 3.5',
 		'Programming Language :: Python :: 3.6',
 		'Programming Language :: Python :: 3.7',
+		'Programming Language :: Python :: 3.8',
 		'Programming Language :: Python',
 		'Topic :: Desktop Environment :: File Managers',
 		'Topic :: Multimedia :: Video',

--- a/test.py
+++ b/test.py
@@ -240,10 +240,10 @@ class TestAPI(unittest.TestCase):
 		self.assertEqual(nielsen.filter_series("The Flash 2014"), "The Flash")
 
 
-	def test_filter_filename(self):
+	def test_sanitize_filename(self):
 		'''Test removing invalid characters from filenames.'''
 		# Invalid characters for POSIX systems
-		self.assertEqual(nielsen.filter_filename(
+		self.assertEqual(nielsen.sanitize_filename(
 			'Brooklyn Nine-Nine -02.20- AC/DC.mp4'),
 			'Brooklyn Nine-Nine -02.20- AC-DC.mp4')
 


### PR DESCRIPTION
Rename 'filter_filename` to `sanitize_filename` and add a `system_type`
parameter to change which OS type it will sanitize the filename for. By
default, this is set to `os.name` and supports `posix` and `nt`.

Streamline the behavior of `filter_series`. This function now returns
the given string in title case unless a custom name is found.

Update list of supported Python versions to a minimum of Python 3.6
(which is required for f-strings).

Bump version to `2.1.3`.

Resolves #72.