### PR TITLE
Change versions of Python Travis CI tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 language: python
 python:
-  - "3.3"
-  - "3.4"
-  - "3.5"
   - "3.6"
+  - "3.7"
+  - "3.8"
   - "nightly"
 # command to install dependencies
 install:


### PR DESCRIPTION
Change the versions of Python that Travis CI tests against to a minimum
of Python 3.6 (required for f-strings) up through the nightly version.