### PR TITLE
Add the ability to customize output filenames

### DIFF
--- a/nielsen.ini
+++ b/nielsen.ini
@@ -10,6 +10,7 @@ FetchTitles = True
 Interactive = True
 OrganizeFiles = True
 ServiceURI = http://api.tvmaze.com/
+Format = {series} -{season}.{episode}- {title}.{extension}
 
 [Filters]
 Archer (2009) = Archer

--- a/nielsen/api.py
+++ b/nielsen/api.py
@@ -151,7 +151,7 @@ def process_file(filename):
 	info = get_file_info(file)
 	if info:
 		# Define a format for the renamed file
-		form = "{series} -{season}.{episode}- {title}.{extension}"
+		form = CONFIG.get('Options', 'Format')
 		# Generate the new filename
 		name = sanitize_filename(form.format(**info))
 		logging.info("Rename to: '%s'", name)

--- a/nielsen/config.py
+++ b/nielsen/config.py
@@ -23,6 +23,7 @@ CONFIG['Options'] = {
 	'DryRun': 'False',
 	'FetchTitles': 'False',
 	'ServiceURI': 'http://api.tvmaze.com/',
+	'Format': '{series} -{season}.{episode}- {title}.{extension}',
 }
 
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup
 
 setup(
 	name='Nielsen',
-	version='2.1.3',
+	version='2.2.0',
 	author="Michael 'Irish' O'Neill",
 	author_email="irish.dot@gmail.com",
 	url='https://github.com/IrishPrime/nielsen/',


### PR DESCRIPTION
Add a new option to the configuration: `format`. This option determines
the new filename of files processed by `nielsen`. It supports the
following tokens: `{series}`, `{season}`, `{episode}`, `{title}`,
`{extension}`.

The default format remains unchanged and has been added to the sample
`nielsen.ini` to preserve existing behavior and suggest the ability to
modify it.

Resolves #21.