### PR TITLE
Restore dry-run functionality

### DIFF
--- a/nielsen/files.py
+++ b/nielsen/files.py
@@ -27,7 +27,6 @@ def set_file_ownership(file):
 		try:
 			chown(file, CONFIG.get('Options', 'User') or None,
 				CONFIG.get('Options', 'Group') or None)
-			status = True
 		except PermissionError as err:
 			logging.error("chown failed. %s", err)
 			raise

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup
 
 setup(
 	name='Nielsen',
-	version='2.2.1',
+	version='2.2.2',
 	author="Michael 'Irish' O'Neill",
 	author_email="irish.dot@gmail.com",
 	url='https://github.com/IrishPrime/nielsen/',

--- a/test.py
+++ b/test.py
@@ -3,6 +3,8 @@
 
 import unittest
 import unittest.mock
+import pathlib
+import tempfile
 import nielsen
 
 # Ensure config is loaded regardless of test order
@@ -255,6 +257,25 @@ class TestAPI(unittest.TestCase):
 		self.assertEqual(nielsen.sanitize_filename(
 			'Brooklyn Nine-Nine -02.20- AC/DC.mp4'),
 			'Brooklyn Nine-Nine -02.20- AC-DC.mp4')
+
+
+	def test_organize_file(self):
+		'''Test for the correct file path/hierarchy.'''
+		series = 'Firefly'
+		season = '01'
+		filename = "Firefly -01.01- Serenity.mkv"
+
+		# Set the MediaPath to a temporary directory to avoid conflicting with
+		# real file paths. Set the dryrun argument to True to avoid modifying
+		# the filesystem. Test the filesystem afterwards to confirm no
+		# directories were created.
+		with tempfile.TemporaryDirectory() as tmp:
+			nielsen.CONFIG.set('Options', 'MediaPath', tmp)
+			dst = nielsen.organize_file(filename, 'Firefly', '01', True)
+			self.assertEqual(
+				pathlib.PurePath(tmp, series, f'Season {season}', filename),
+				dst)
+			self.assertFalse(dst.parent.exists())
 
 
 class TestTV(unittest.TestCase):


### PR DESCRIPTION
Add a `dryrun` parameter to the `organize_file` and `process_file`
functions in the `api` module. Get the value for this parameter from the
`CONFIG` object by default.

Add checks for the `dryrun` parameter before performing operations which
modify files or the filesystem. This functionality was broken when
adding support for `pathlib`.

Add unit test for `organize_file`.

Bump version to 2.2.2.

Resolve #83.