### PR TITLE
Add --(no-)filter option

### DIFF
--- a/bin/cli.py
+++ b/bin/cli.py
@@ -38,6 +38,13 @@ def main():
 	group.add_argument("--no-fetch", dest="fetch", action="store_const",
 		const='False', help="Do not fetch titles from the web")
 
+	# Filter series
+	group = ap.add_mutually_exclusive_group()
+	group.add_argument("--filter", dest="filter", action="store_const",
+		const='True', help="Replace series name with user-defined alternative or title-case")
+	group.add_argument("--no-filter", dest="filter", action="store_const",
+		const='False', help="Do not modify series names")
+
 	# Interactive series selection
 	group = ap.add_mutually_exclusive_group()
 	group.add_argument("-i", "--interactive", dest="interactive",
@@ -66,11 +73,26 @@ def main():
 	nielsen.config.load_config(args.config_file)
 
 	# Override the settings in the config file if given on the command line
-	if args.user:
-		nielsen.config.CONFIG.set('Options', 'User', args.user)
+	if args.dry_run:
+		nielsen.config.CONFIG.set('Options', 'DryRun', args.dry_run)
+
+	if args.fetch:
+		nielsen.config.CONFIG.set('Options', 'FetchTitles', args.fetch)
+
+	if args.filter:
+		nielsen.config.CONFIG.set('Options', 'FilterSeries', args.filter)
 
 	if args.group:
 		nielsen.config.CONFIG.set('Options', 'Group', args.group)
+
+	if args.interactive:
+		nielsen.config.CONFIG.set('Options', 'Interactive', args.interactive)
+
+	if args.log_level:
+		nielsen.config.CONFIG.set('Options', 'LogLevel', args.log_level.upper())
+
+	if args.mediapath:
+		nielsen.config.CONFIG.set('Options', 'MediaPath', args.mediapath)
 
 	if args.mode:
 		nielsen.config.CONFIG.set('Options', 'Mode', args.mode)
@@ -78,20 +100,8 @@ def main():
 	if args.organize:
 		nielsen.config.CONFIG.set('Options', 'OrganizeFiles', args.organize)
 
-	if args.fetch:
-		nielsen.config.CONFIG.set('Options', 'FetchTitles', args.fetch)
-
-	if args.interactive:
-		nielsen.config.CONFIG.set('Options', 'Interactive', args.interactive)
-
-	if args.dry_run:
-		nielsen.config.CONFIG.set('Options', 'DryRun', args.dry_run)
-
-	if args.mediapath:
-		nielsen.config.CONFIG.set('Options', 'MediaPath', args.mediapath)
-
-	if args.log_level:
-		nielsen.config.CONFIG.set('Options', 'LogLevel', args.log_level.upper())
+	if args.user:
+		nielsen.config.CONFIG.set('Options', 'User', args.user)
 
 	# Configure logging
 	logging.basicConfig(filename=nielsen.config.CONFIG.get('Options', 'LogFile'),
@@ -103,7 +113,7 @@ def main():
 
 	# Iterate over files
 	for f in args.FILE:
-		nielsen.api.process_file(f)
+		nielsen.api.process_file(f, args.dry_run)
 
 	# Add series IDs to config file
 	nielsen.config.update_series_ids(args.config_file)

--- a/nielsen.ini
+++ b/nielsen.ini
@@ -1,16 +1,17 @@
 [Options]
-User = irish
+DryRun = True
+FetchTitles = True
+FilterSeries = True
+Format = {series} -{season}.{episode}- {title}.{extension}
 Group = irish
-Mode = 664
+Interactive = True
 LogFile = /var/log/nielsen.log
 LogLevel = DEBUG
 MediaPath = /home/irish/Videos/TV/
-DryRun = False
-FetchTitles = True
-Interactive = True
+Mode = 664
 OrganizeFiles = True
 ServiceURI = http://api.tvmaze.com/
-Format = {series} -{season}.{episode}- {title}.{extension}
+User = irish
 
 [Filters]
 Archer (2009) = Archer

--- a/nielsen/api.py
+++ b/nielsen/api.py
@@ -64,7 +64,8 @@ def get_file_info(file):
 			info['title'] = info.get('title', '').replace('.', ' ').strip()
 
 			# Check series name against filter
-			info['series'] = filter_series(info['series'])
+			if CONFIG.getboolean('Options', 'FilterSeries'):
+				info['series'] = filter_series(info['series'])
 
 			# Strip tags and release notes from the episode title
 			info['title'] = re.sub(tags, "", info['title']).strip()
@@ -172,8 +173,9 @@ def process_file(filename, dryrun=CONFIG.getboolean('Options', 'DryRun')):
 			# Rename file in-place, updating Path object
 			file = file.rename(clean)
 
-		if CONFIG.getboolean('Options', 'OrganizeFiles'):
+		if CONFIG.getboolean('Options', 'OrganizeFiles') and not dryrun:
 			# Move file to appropiate location under MediaPath
+			logging.info('Organizing %s', filename)
 			file = organize_file(file, info['series'], info['season'], dryrun)
 
 	return file

--- a/nielsen/config.py
+++ b/nielsen/config.py
@@ -12,18 +12,19 @@ CONFIG.add_section('Options')
 CONFIG.add_section('Filters')
 CONFIG.add_section('IDs')
 CONFIG['Options'] = {
-	'User': '',
+	'DryRun': 'False',
+	'FetchTitles': 'False',
+	'FilterSeries': 'True',
+	'Format': '{series} -{season}.{episode}- {title}.{extension}',
 	'Group': '',
-	'Mode': '644',
 	'Interactive': 'False',
 	'LogFile': 'nielsen.log',
 	'LogLevel': 'WARNING',
 	'MediaPath': '',
+	'Mode': '644',
 	'OrganizeFiles': 'False',
-	'DryRun': 'False',
-	'FetchTitles': 'False',
 	'ServiceURI': 'http://api.tvmaze.com/',
-	'Format': '{series} -{season}.{episode}- {title}.{extension}',
+	'User': '',
 }
 
 

--- a/nielsen/files.py
+++ b/nielsen/files.py
@@ -35,16 +35,17 @@ def set_file_ownership(file):
 def create_hierarchy(file):
 	'''Create the directory hierarchy for the given `file`.'''
 	try:
+		# Use the file mode from the configuration, but ensure the executable
+		# bit is set when creating directories so that the directories can
+		# actually be entered
+		dir_mode = int(CONFIG.get('Options', 'mode'), 8) | 0o111
 		# Create the parent directories of the file path if they don't exist
-		file.parent.mkdir(mode=int(CONFIG.get('Options', 'mode'), 8),
-				parents=True, exist_ok=True)
-		logging.debug('Created: %s', file.parent)
-		status = True
+		file.parent.mkdir(mode=dir_mode, parents=True, exist_ok=True)
+		logging.info('Created: %s', file.parent)
 	except FileExistsError:
-		logging.debug('%s already exists', file.parent)
+		logging.info('%s already exists', file.parent)
 	except PermissionError as err:
 		logging.error(err)
-		raise
 
 
 def move(src, dst):
@@ -52,9 +53,10 @@ def move(src, dst):
 	if dst.exists() or src == dst:
 		# If the destination file already exists, or the source and destination
 		# point to the same path, take no further actions
-		logging.debug('%s already in MediaPath. File will not be moved.', dst)
+		logging.info('%s already in MediaPath. File will not be moved.', dst)
 
 	try:
+		logging.info('Moving %s to %s', src, dst)
 		su_move(src, dst)
 	except PermissionError as err:
 		logging.error(err)

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup
 
 setup(
 	name='Nielsen',
-	version='2.2.2',
+	version='2.3.0',
 	author="Michael 'Irish' O'Neill",
 	author_email="irish.dot@gmail.com",
 	url='https://github.com/IrishPrime/nielsen/',


### PR DESCRIPTION
Add a `--(no-)fiter` option to toggle series filtering behavior at
runtime.

Alphabetize some lists in the source and configuration file

Ensure that directories created by the `create_hierarchy()` function
will always create directories with the executable bit set so that they
can be entered.

Log more things at the `info` level rather than the `debug` level,
preferring `debug` for data structures rather than actions.

Bump version to 2.3.0.

Resolve #84.