### PR TITLE
Add a `Media(TV)` class

### DIFF
--- a/fixtures/config.ini
+++ b/fixtures/config.ini
@@ -1,2 +1,8 @@
 [unit tests]
 foo = bar
+
+[media]
+library = fixtures/media/
+
+[tv]
+library = fixtures/tv/

--- a/nielsen/config.py
+++ b/nielsen/config.py
@@ -8,23 +8,35 @@ from typing import Optional
 logger: logging.Logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())
 
-config: ConfigParser = ConfigParser()
+config: ConfigParser = ConfigParser(converters={"path": pathlib.Path})
+# Set default options
+config["DEFAULT"] = {
+    # Dry Run - Outputs results without actually modifying files
+    "dryrun": "False",
+    # Fetch - Whether to query remote sources for information
+    "fetch": "True",
+    # Filter - Whether to refer to the <type>/filter section when organizing Media
+    "filter": "True",
+    # Interactive - Whether to prompt the user to make decisions while processing
+    "interactive": "True",
+    # Library - The directory under which Media should be organized
+    "library": str(pathlib.Path.home()),
+    # LogFile - The file to which log messages should be written
+    "logfile": "~/.local/log/nielsen/nielsen.log",
+    # LogLevel - The minimum log-level to display
+    "loglevel": "WARNING",
+    # Mode - The file mode (permissions) to set on Media files during processing
+    "mode": "664",
+    # Organize - Whether to move Media to its library directory
+    "organize": "True",
+    # Rename - Whether to rename individual Media files
+    "rename": "True",
+}
 
 
 def load_config(path: Optional[pathlib.Path] = None) -> ConfigParser:
     """Load a configuration from a file. If no file path is provided, default
     configuration file locations are used. Returns a ConfigParser object."""
-
-    # Set some default options
-    config.set(config.default_section, "dryrun", "False")
-    config.set(config.default_section, "fetch", "True")
-    config.set(config.default_section, "filter", "True")
-    config.set(config.default_section, "interactive", "True")
-    config.set(config.default_section, "logfile", "~/.local/log/nielsen/nielsen.log")
-    config.set(config.default_section, "loglevel", "WARNING")
-    config.set(config.default_section, "mediapath", str(pathlib.Path.home()))
-    config.set(config.default_section, "mode", "664")
-    config.set(config.default_section, "organize", "True")
 
     if not path:
         files: list[str] = config.read(
@@ -48,8 +60,8 @@ def load_config(path: Optional[pathlib.Path] = None) -> ConfigParser:
 def write_config(path: pathlib.Path) -> None:
     """Write the global configuration object to the given `path`."""
 
-    with open(path, "w") as fp:
-        config.write(fp)
+    with open(path, mode="w") as file:
+        config.write(file)
 
 
-# vim: et ts=4 sts=4 sw=4
+# vim: tabstop=4 softtabstop=4 shiftwidth=4 expandtab

--- a/nielsen/config.py
+++ b/nielsen/config.py
@@ -15,8 +15,8 @@ config["DEFAULT"] = {
     "dryrun": "False",
     # Fetch - Whether to query remote sources for information
     "fetch": "True",
-    # Filter - Whether to refer to the <type>/filter section when organizing Media
-    "filter": "True",
+    # Transform - Whether to refer to the <type>/<field>/transform section when organizing Media
+    "transform": "True",
     # Interactive - Whether to prompt the user to make decisions while processing
     "interactive": "True",
     # Library - The directory under which Media should be organized

--- a/nielsen/media.py
+++ b/nielsen/media.py
@@ -30,4 +30,30 @@ class Media(ABC):
         """Move the file to the appropriate media library on disk."""
 
 
+@dataclass(order=True, slots=True)
+class TV(Media):
+    """A class just for TV shows."""
+
+    series: str = ""
+    season: int = 0
+    episode: int = 0
+    title: str = ""
+
+    def infer(self):
+        self.series = "The Wheel of Time"
+        self.season = 1
+        self.episode = 8
+        self.title = "The Eye of the World"
+
+    def organize(self) -> pathlib.Path:
+        """Move the file to the TV media library location."""
+        return pathlib.Path(f"/tmp/organized/{self}")
+
+    def __str__(self) -> str:
+        """Return a friendly, human-readable version of the file metadata, fit for
+        renaming or display purposes."""
+
+        return f"{self.series} -{self.season:02d}.{self.episode:02d}- {self.title}"
+
+
 # vim: et ts=4 sts=4 sw=4

--- a/nielsen/media.py
+++ b/nielsen/media.py
@@ -121,6 +121,12 @@ class TV(Media):
     def infer(self):
         """Infer information about the object's metadata based on its filename."""
 
+    def get_patterns(self) -> list[str]:
+        """Return a list of strings representing the filename patterns that should be
+        matched against when attempting to infer metadata information."""
+
+        pass
+
     def __str__(self) -> str:
         """Return a friendly, human-readable version of the file metadata, fit for
         renaming or display purposes."""

--- a/nielsen/media.py
+++ b/nielsen/media.py
@@ -119,16 +119,13 @@ class TV(Media):
     title: str = ""
 
     def infer(self):
-        self.series = "The Wheel of Time"
-        self.season = 1
-        self.episode = 8
-        self.title = "The Eye of the World"
+        """Infer information about the object's metadata based on its filename."""
 
     def __str__(self) -> str:
         """Return a friendly, human-readable version of the file metadata, fit for
         renaming or display purposes."""
 
-        return f"{self.series} -{self.season:02d}.{self.episode:02d}- {self.title}"
+        return f"{self.series or 'Unknown'} -{self.season:02d}.{self.episode:02d}- {self.title or 'Unknown'}"
 
 
 # vim: tabstop=4 softtabstop=4 shiftwidth=4 expandtab

--- a/nielsen/media.py
+++ b/nielsen/media.py
@@ -1,33 +1,112 @@
 """Class defintitions for all Media types."""
 
-from abc import ABC
-from abc import abstractmethod
-from dataclasses import dataclass
-from typing import Optional
 import logging
 import pathlib
+from dataclasses import dataclass, field
+from typing import Any, Optional
+
+from nielsen.config import config
+
+logger: logging.Logger = logging.getLogger(__name__)
+logger.addHandler(logging.NullHandler())
 
 
 @dataclass(slots=True)
-class Media(ABC):
+class Media:
     """Media objects represent a file to be managed and its metadata."""
 
-    path: Optional[pathlib.Path | str]
+    path: Optional[pathlib.Path] = None
+    _section: str = field(
+        init=False, repr=False, hash=False, compare=False, metadata=None
+    )
+    _library: pathlib.Path = field(
+        init=False, repr=False, hash=False, compare=False, metadata=None
+    )
 
     def __post_init__(self):
-        if not self.path:
+        if isinstance(self.path, pathlib.Path):
+            self.path = self.path.resolve()
+        else:
             self.path = None
-        elif self.path and not isinstance(self.path, pathlib.Path):
-            logging.debug("Convert %s to pathlib.Path", self.path)
-            self.path = pathlib.Path(self.path)
 
-    @abstractmethod
-    def infer(self):
+        # By default, instances of a subclass should use the section of the config
+        # corresponding to their type name.
+        self.section = self.__class__.__name__.lower()
+
+        # Similarly, the library should be pulled from the section of the config
+        # corresponding to the type name.
+        self.library = config.getpath(self.section, "library").resolve()  # type: ignore
+
+    @property
+    def library(self) -> pathlib.Path:
+        """Return a Path object representing the root of the library for the Media type
+        from the config."""
+
+        return self._library
+
+    @library.setter
+    def library(self, value: pathlib.Path) -> None:
+        """Set the library property. Attempt to coerce the value to a Path if not
+        provided as such."""
+
+        if not isinstance(value, pathlib.Path):
+            try:
+                value = pathlib.Path(value)
+            except TypeError:
+                logger.exception("Could not coerce value to Path: %s", repr(value))
+                raise
+
+        self._library = value.resolve()
+
+    @property
+    def section(self) -> str:
+        """Return a string denoting which section of the ConfigParser this Media should
+        refer to when looking for its options."""
+
+        return self._section
+
+    @section.setter
+    def section(self, value: str) -> None:
+        """Set the section in the ConfigParser to refer to for options."""
+
+        if not config.has_section(value):
+            config.add_section(value)
+
+        self._section = value
+
+    def infer(self) -> dict[str, Any]:
         """Infer information about the object's metadata based on its filename."""
 
-    @abstractmethod
-    def organize(self):
+        raise NotImplementedError
+
+    def organize(self) -> pathlib.Path:
         """Move the file to the appropriate media library on disk."""
+
+        if not isinstance(self.path, pathlib.Path):
+            logger.error("Path attribute is not of type Path: %s", self.path)
+            raise TypeError(self.path)
+
+        if not self.path.is_file():
+            logger.error(
+                "Path attribute does not point to a regular file: %s", self.path
+            )
+            raise TypeError(self.path)
+
+        if not self.library.is_dir():
+            try:
+                self.library.mkdir(exist_ok=True)
+            except (PermissionError, NotADirectoryError):
+                logger.exception(
+                    "Library directory does not exist and could not be created: %s",
+                    self.library,
+                )
+                raise
+
+        logger.info("Move %s to %s.", self.path.name, self.library)
+        self.path = self.path.rename(self.library / self.path.name).resolve()
+        logger.debug("New path: %s", self.path)
+
+        return self.path
 
 
 @dataclass(order=True, slots=True)
@@ -45,10 +124,6 @@ class TV(Media):
         self.episode = 8
         self.title = "The Eye of the World"
 
-    def organize(self) -> pathlib.Path:
-        """Move the file to the TV media library location."""
-        return pathlib.Path(f"/tmp/organized/{self}")
-
     def __str__(self) -> str:
         """Return a friendly, human-readable version of the file metadata, fit for
         renaming or display purposes."""
@@ -56,4 +131,4 @@ class TV(Media):
         return f"{self.series} -{self.season:02d}.{self.episode:02d}- {self.title}"
 
 
-# vim: et ts=4 sts=4 sw=4
+# vim: tabstop=4 softtabstop=4 shiftwidth=4 expandtab


### PR DESCRIPTION
Add a `Media(TV)` class with fields for:
- Series name
- Season number
- Episode number
- Episode title

Add a `Media.patterns` property. This property holds all the compiled
regular expressions used to attempt to infer metadata for an instance
based on its filename.

Add `Media.load_patterns()` and `Media._load_patterns()` methods to
allow each subclass to handle loading or generating patterns in their
own way.

Add a `Media.infer()` method which uses the filename and
`Media.patterns` to infer the metadata. This metadata is passed to the
`Media.set_metadata()` method, which must be implemented by each
subclass, to further process or transform values before finally
assigning them.

Add a `Media._match()` helper method to perform matches for
`Media.infer()` against `Media.patterns` and return the metadata.

Improve documentation for the `nielsen.media` module.

Add tests for new functionality.

Resolve #88.