### PR TITLE
Add more robust tests for `TV.infer`

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,21 @@
+[report]
+# Regexes for lines to exclude from consideration
+exclude_lines =
+	# Have to re-enable the standard pragma
+	pragma: no cover
+
+	# Don't complain about missing debug-only code:
+	def __repr__
+	if self\.debug
+
+	# Don't complain if tests don't hit defensive assertion code:
+	raise AssertionError
+	raise NotImplementedError
+
+	# Don't complain if non-runnable code isn't run:
+	if 0:
+	if __name__ == .__main__.:
+
+	# Don't complain about abstract methods, they aren't run:
+	@(abc\.)?abstractmethod
+	\.\.\.

--- a/bin/pickler.py
+++ b/bin/pickler.py
@@ -41,11 +41,10 @@ def tvmaze() -> None:
     TRANSLATION = str.maketrans({" ": "-", "=": "-", "&": "-"})
     queries: list[dict[str, str]] = [
         {"api": "singlesearch/shows", "params": "q=Ted+Lasso"},
+        {"api": "singlesearch/shows", "params": "q=useless+search+string"},
         {"api": "search/shows", "params": "q=Ted+Lasso"},
-        {
-            "api": "search/shows",
-            "params": "q=Agents+of+SHIELD",
-        },
+        {"api": "search/shows", "params": "q=useless+search+string"},
+        {"api": "search/shows", "params": "q=Agents+of+SHIELD"},
         {"api": "shows/44458/episodebynumber", "params": "season=1&number=3"},
     ]
 
@@ -57,8 +56,7 @@ def tvmaze() -> None:
 
         logger.debug(response.json())
 
-        if response.ok:
-            pickle_data(response, path)
+        pickle_data(response, path)
 
 
 if __name__ == "__main__":

--- a/fixtures/config.ini
+++ b/fixtures/config.ini
@@ -1,3 +1,15 @@
+[DEFAULT]
+dryrun = False
+fetch = True
+transform = True
+interactive = False
+library = /home/irish
+logfile = ~/.local/log/nielsen/nielsen.log
+loglevel = WARNING
+mode = 664
+organize = True
+rename = True
+
 [unit tests]
 foo = bar
 
@@ -7,5 +19,21 @@ library = fixtures/media/
 [tv]
 library = fixtures/tv/
 
+[tv/transform/series]
+game of thrones = Game of Thrones
+person of interest = Person of Interest
+castle (2009) = Castle
+
 [tvmaze/ids]
-Ted Lasso = 44458
+ted lasso = 44458
+the glades = 571
+firefly = 180
+supernatural = 19
+pushing daisies = 918
+person of interest = 2
+castle = 68
+the flash = 13
+game of thrones = 82
+bones = 65
+limitless = 2473
+

--- a/nielsen/config.py
+++ b/nielsen/config.py
@@ -74,7 +74,7 @@ def update_config(path: pathlib.Path) -> None:  # pragma: no cover
     other dynamic changes to the config will be reverted before the file is written."""
 
     load_config()
-    write_config(pathlib.Path("~/.config/nielsen/config.ini").expanduser())
+    write_config(path.expanduser())
 
 
 # vim: tabstop=4 softtabstop=4 shiftwidth=4 expandtab

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,8 @@ readme = "README.md"
 [tool.poetry.dependencies]
 python = "^3.10"
 requests = "^2.28.1"
+typer = "^0.7.0"
+rich = "^13.3.3"
 
 [tool.poetry.group.dev.dependencies]
 coverage = "^7.0.3"


### PR DESCRIPTION
Improve pattern matching for `TV(Media)`. More reliably detect a year following the series name.

Allow `bin/pickler.py` to pickle responses even if they aren't `ok` (in order to test for failures).

Use `string.capwords` rather than `str.title` to handle title-casing (mostly to avoid capital letters after apostrophes).

Change some `Optional` return types to return falsey values of the same type rather than `None` on failure to simplify type-checking and error handling.

Add `.coveragerc` to ensure proper configuration of test coverage reporting.