### PR TITLE
Make `Media.path` required

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 test:
-	-coverage run -m unittest discover
-	-coverage html nielsen/*.py
-	-coverage report nielsen/*.py
+	-coverage run --omit nielsen/logging.py -m unittest discover
+	-coverage html --omit nielsen/logging.py --skip-empty nielsen/*.py
+	-coverage report --omit nielsen/logging.py --skip-empty nielsen/*.py
 
 # Run the pickler script, which makes actual calls to remote APIs and pickles
 # the responses so further tests can be run against the saved responses rather

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ rich = "^13.3.3"
 coverage = "^7.0"
 black = "^23.0"
 mypy = "^1.0"
+types-requests = "^2.31.0.8"
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
Make `Media.path` a required property of all `Media` objects. Set the `path` in `Media.__post_init__` to ensure it goes through the setter, which coerces the value to a `pathlib.Path` or raises a `TypeError`. This makes it more difficult to create dummy media objects that don't represent a file on disk, but there's no obvious use-case that requires such an object (besides convenience in creating objects for unit tests).

Ensure that `Media.path` is a file (even if it doesn't exist) when setting the property.

Ensure that `Media.library` is a directory (even if it doesn't exist) when setting the property.

Add `types-requests` as a development dependency for better type checking.

Omit `nielsen/logging.py` from `coverage` tests and reports.

Resolve #101.