### PR TITLE
Add `nielsen.processor` module

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -2,7 +2,7 @@
 
 ## Abstractions
 
-### Media
+### `Media`
 
 `Media` objects represent a file to be managed and its metadata. While the base
 `Media` class can be instantiated, it's not especially useful on its own,
@@ -16,13 +16,20 @@ The base `Media` class defines the following attributes and methods:
 1. `patterns`: A list of compiled regular expression `Pattern`s that are
    considered when attempting to infer metadata information about the object
    based on the filename (`path`).
+1. `library`: A `pathlib.Path` representing the root of the library for the
+   `Media` type from the configuration.
+1. `orgdir`: A `pathlib.Path` representing the sub-directory of the `library`
+   into which a `Media` object will be moved by the `organize` method.
+1. `metadata`: A property which returns all metadata as a dictionary, intended
+   for ease of inspection and discovery. This is not implemented in the base
+   class, but should be implemented by subclasses.
 1. `infer`: A method which attempts to infer metadata about the file (e.g. from
    its filename) and updates the appropriate metadata attributes with this
    information.
 1. `organize`: A method which attempts to move the file to a new location,
    updates the `path` attribute on success, and returning this new value.
-1. `metadata`: A property which returns all metadata as a dictionary, intended
-   for ease of inspection and discovery.
+1. `section`: A `str` which represents the section name of the `ConfigParser`
+   from which settings for this `Media` object are retrieved.
 
 The metadata keys are not defined as part of this base class because all types
 of media have different relevant pieces of metadata. For example, TV shows
@@ -30,18 +37,44 @@ don't have an album name, movies don't have an episode number, music doesn't
 have a season, etc. As such, each subtype is free to define its own metadata,
 but that metadata should exposed as instance attributes.
 
-### Fetcher
+### `Fetcher`
 
 The `Fetcher` Protocol is used to fetch metadata from sources which aren't
 intrinsic to the `Media` object (e.g. making an external API request to TVMaze,
 IMDB, etc.).
 
 Other classes must implement their own `fetch` method to conform to this
-protocol.
-
+protocol. The Protocol accepts any subclass of `Media`.
 
 ```python
-def fetch(self, media: nielsen.media.Media) -> None:
-    """Fetch and update metadata using information from the given `Media` object."""
-    ...
+MediaType = TypeVar("MediaType", bound=nielsen.media.Media)
+
+class Fetcher(Protocol):
+    def fetch(self, media: MediaType) -> None:
+        ...
 ```
+
+### `Processor`
+
+`Processor` objects are inteded to provide a convenient way to exercise all
+functionality provided by the rest of the application without all front-ends
+being forced to provide their own implementations.
+
+Instances of the class are created with a type reference to a `Media` subclass
+and a `Fetcher` instance. Instances expose a single method, `process`, which
+accepts a `pathlib.Path` object as an argument.
+
+The `Processor.process` method uses the `Media` type reference to determine
+which type of `Media` subclass to create from the given `Path`, calss
+`Media.infer()` to infer whatever information it can from the filename, and the
+`Fetcher` instance to fetch additional metadata. Finally, the `Processor` will
+call the `Media.rename()` and `Media.organize()` methods to make use of this
+metadata and place the files where they belong.
+
+### `ProcessorFactory`
+
+The `ProcessorFactory` accepts a type reference to a `Media` subclass and a
+`Fetcher` and returns a `Processor` instance.
+
+The `nielsen.processor` module also provides a `PROCESSOR_FACTORIES` dictionary
+containing instances of useful `ProcessorFactory` presets.

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 test:
-	-coverage run --omit nielsen/logging.py -m unittest discover
-	-coverage html --omit nielsen/logging.py --skip-empty nielsen/*.py
-	-coverage report --omit nielsen/logging.py --skip-empty nielsen/*.py
+	-coverage run -m pytest test.py
+	-coverage html --skip-empty nielsen/*.py
+	-coverage report --skip-empty nielsen/*.py
 
 # Run the pickler script, which makes actual calls to remote APIs and pickles
 # the responses so further tests can be run against the saved responses rather
@@ -9,5 +9,11 @@ test:
 pickle:
 	./bin/pickler.py
 
+# Install and source the completion script for zsh
+zsh:
+	nielsen --install-completion zsh
+	$(shell source ~/.zfunc/_nielsen)
+
 .PHONY: test
 .PHONY: pickle
+.PHONY: zsh

--- a/fixtures/config.ini
+++ b/fixtures/config.ini
@@ -1,11 +1,11 @@
-[DEFAULT]
-dryrun = False
+[nielsen]
+simulate = False
 fetch = True
 transform = True
 interactive = False
 library = /home/irish
 logfile = ~/.local/log/nielsen/nielsen.log
-loglevel = DEBUG
+loglevel = INFO
 mode = 664
 organize = True
 rename = True
@@ -37,3 +37,4 @@ game of thrones = 82
 bones = 65
 limitless = 2473
 
+# vim: filetype=config syntax=dosini

--- a/nielsen/config.py
+++ b/nielsen/config.py
@@ -13,11 +13,13 @@ CONFIG_FILE_LOCATIONS: list[str | pathlib.Path] = [
     pathlib.Path("~/.config/nielsen/config.ini").expanduser(),
 ]
 
+# Add a getpath converter.
 config: ConfigParser = ConfigParser(converters={"path": pathlib.Path})
+
 # Set default options
-config["DEFAULT"] = {
+config[config.default_section] = {
     # Dry Run - Outputs results without actually modifying files
-    "dryrun": "False",
+    "simulate": "False",
     # Fetch - Whether to query remote sources for information
     "fetch": "True",
     # Transform - Whether to refer to the <type>/<field>/transform section when organizing Media

--- a/nielsen/fetcher.py
+++ b/nielsen/fetcher.py
@@ -3,6 +3,7 @@
 from typing import Any
 from typing import Optional
 from typing import Protocol
+from typing import TypeVar
 import logging
 import urllib.parse
 
@@ -15,12 +16,14 @@ from nielsen.config import config
 logger: logging.Logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())
 
+MediaType = TypeVar("MediaType", bound=nielsen.media.Media)
+
 
 class Fetcher(Protocol):
     """Used to fetch metadata from an external source rather than infering it from the
     file name."""
 
-    def fetch(self, media: nielsen.media.Media) -> None:
+    def fetch(self, media: MediaType) -> None:
         """Fetch and update metadata using information from the given `Media` object."""
         ...
 

--- a/nielsen/logging.py
+++ b/nielsen/logging.py
@@ -1,8 +1,0 @@
-"""Logging configuration for use in the various Nielsen modules."""
-
-import logging
-
-logging.basicConfig(
-    format="[%(filename)s][%(funcname)s][%(levelname)-8s]%(message)s",
-    datefmt="%Y-%m-%d %H:%M:%S",
-)

--- a/nielsen/processor.py
+++ b/nielsen/processor.py
@@ -1,0 +1,77 @@
+"""A collection of classes used to orchestrate combinations of Media and Fetcher
+operations to be used by any frontend application.
+
+Rather than creating individual Media instances of a specific subclass and a Fetcher
+instance and manually calling all of their individual methods, Processors provide a
+convenience method (process) which creates a Media instance of the desired type and
+handles all changes to that Media instance."""
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Type
+import pathlib
+
+from nielsen.config import config
+import nielsen.fetcher
+import nielsen.media
+
+
+class MediaType(Enum):
+    TV = "tv"
+
+
+@dataclass
+class Processor:
+    """A convenience class to handle all the Media and Fetcher operations required to
+    manage an individual file. The `media_type` is a Media class and is used to
+    construct instances of the given type. The `fetcher` is an instance of an object
+    implementing the `Fetcher` Protocol."""
+
+    media_type: Type[nielsen.media.Media]
+    fetcher: nielsen.fetcher.Fetcher
+
+    def process(self, path: pathlib.Path) -> nielsen.media.Media:
+        """Convenience function to process Media for storage in its library, respecting the configuration
+        options (so some steps may be skipped).
+        1. Infer metadata based on the Media type.
+        2. Fetch missing data.
+        3. Rename the file.
+        4. Move the file to the appropriate directory.
+        5. Modify file ownership and mode.
+        """
+
+        # Create an instance of the appropriate Media subclass
+        media: nielsen.media.Media = self.media_type(path)
+
+        media.infer()
+
+        if config.getboolean(media.section, "fetch"):
+            self.fetcher.fetch(media)
+
+        if config.getboolean(media.section, "rename"):
+            media.rename()
+
+        if config.getboolean(media.section, "organize"):
+            media.organize()
+
+        return media
+
+
+@dataclass
+class ProcessorFactory:
+    """A Factory class for Processors. Given a Media and Fetcher class, calling an
+    instance of this Factory will return a Processor with the given Media class and
+    Fetcher instance."""
+
+    media_type: Type[nielsen.media.Media]
+    fetcher: Type[nielsen.fetcher.Fetcher]
+
+    def __call__(self) -> Processor:
+        """Return a Processor for the given types."""
+
+        return Processor(self.media_type, self.fetcher())
+
+
+PROCESSOR_FACTORIES: dict[MediaType, ProcessorFactory] = {
+    MediaType.TV: ProcessorFactory(nielsen.media.TV, nielsen.fetcher.TVMaze),
+}


### PR DESCRIPTION
Add `nielsen.processor` module, which provides a `Processor` and `ProcessorFactory` class. These classes should simplify orchestrating which type of `Media` subclass and `Fetcher` to create, as well as calling the `Media.infer`, `Fetcher.fetch`, `Media.rename`, and `Media.organize` methods to fully process a given file.

Resolve #103.