### PR TITLE
Add file ownership and mode functionality when organizing files

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,15 +121,6 @@ the first result is used.
 
 *Default*: `True`
 
-##### `library`
-
-The root directory into which a file should be moved as part of its processing.
-Each `Media` type may define its own `library` path.
-
-*Value*: *A directory the user can write to*
-
-*Default*: `$HOME`
-
 ##### `logfile`
 
 The location on disk to which `nielsen` log output should be written.
@@ -191,7 +182,37 @@ processing. The exact nature of these transformations are defined by the
 #### `[media]`
 
 Contains options to apply to generic `Media` objects. Currently, there's no
-real use for this.
+real use for this. However, options described here can be used in any other
+`Media` type section (e.g. `tv`).
+
+##### `library`
+
+The root directory into which a file should be moved as part of its processing.
+Each `Media` type may define its own `library` path.
+
+*Value*: *A directory the user can write to*
+
+*Default*: `$HOME`
+
+##### `owner`
+
+The user name or system UID which should own the file after organizing. This
+value is optional, and if left undefined, the file ownership will not be
+changed when organizing.
+
+*Value*: A system username (e.g. `irish`) or UID (e.g. `1000`).
+
+*Default*: `None`
+
+##### `group`
+
+The group name or system GID which should own the file after organizing. This
+value is optional, and if left undefined, the file ownership will not be
+changed when organizing.
+
+*Value*: A system group name (e.g. `user`) or GID (e.g. `1001`).
+
+*Default*: `None`
 
 #### `[tv]`
 

--- a/fixtures/config.ini
+++ b/fixtures/config.ini
@@ -18,6 +18,8 @@ library = fixtures/media/
 
 [tv]
 library = fixtures/tv/
+owner = nielsen_user
+group = nielsen_group
 
 [tv/transform/series]
 game of thrones = Game of Thrones
@@ -25,16 +27,16 @@ person of interest = Person of Interest
 castle (2009) = Castle
 
 [tvmaze/ids]
-ted lasso = 44458
-the glades = 571
-firefly = 180
-supernatural = 19
-pushing daisies = 918
-person of interest = 2
-castle = 68
-the flash = 13
-game of thrones = 82
 bones = 65
+castle = 68
+firefly = 180
+game of thrones = 82
 limitless = 2473
+person of interest = 2
+pushing daisies = 918
+supernatural = 19
+ted lasso = 44458
+the flash = 13
+the glades = 571
 
 # vim: filetype=config syntax=dosini

--- a/nielsen/media.py
+++ b/nielsen/media.py
@@ -24,7 +24,7 @@ import logging
 import pathlib
 import re
 from dataclasses import dataclass, field
-from shutil import move
+from shutil import chown, move
 from string import capwords
 from typing import Any, Pattern
 
@@ -223,6 +223,17 @@ class Media:
                 move(self.path, self.orgdir / self.path.name)
             ).resolve()
             logger.debug("New path: %s", self.path)
+
+        self.path.chmod(int(config.get(self.section, "mode"), 8))
+
+        # If chown gets a None value for user or group, it won't modify the existing
+        # values. Use None as a fallback to leave things alone unless the user has
+        # explicitly set a different value in their configuration.
+        chown(  # type: ignore
+            self.path,
+            user=config.get(self.section, "owner", fallback=None),  # type: ignore
+            group=config.get(self.section, "group", fallback=None),  # type: ignore
+        )
 
         return self.path
 


### PR DESCRIPTION
Modify `nielsen.media.Media.organize` to set the file mode, user, and group as defined in the appropriate configuration section.

Resolve #106.