### PR TITLE
Reorder first two TV matching patterns

### DIFF
--- a/nielsen/media.py
+++ b/nielsen/media.py
@@ -324,14 +324,14 @@ class TV(Media):
         """Load filename patterns for the instance type into the patterns property."""
 
         self.patterns = [
-            # The.Flash.2014.217.Flash.Back.HDTV.x264-LOL[ettv].mp4
-            re.compile(
-                r"(?P<series>.+?)\.+(?P<year>\d{4}|\(\d{4}\))?\.(?P<season>\d{1,2})(?P<episode>\d{2})\.*(?P<title>.*)?\.+(?P<extension>\w+)$",
-                re.IGNORECASE,
-            ),
             # The.Glades.S02E01.Family.Matters.HDTV.XviD-FQM.avi
             re.compile(
                 r"(?P<series>.+?)\.+(?P<year>\d{4}|\(\d{4}\))?\.*S(?P<season>\d{2})\.?E(?P<episode>\d{2})\.*(?P<title>.*)?\.+(?P<extension>\w+)$",
+                re.IGNORECASE,
+            ),
+            # The.Flash.2014.217.Flash.Back.HDTV.x264-LOL[ettv].mp4
+            re.compile(
+                r"(?P<series>.+?)\.+(?P<year>\d{4}|\(\d{4}\))?\.(?P<season>\d{1,2})(?P<episode>\d{2})\.*(?P<title>.*)?\.+(?P<extension>\w+)$",
                 re.IGNORECASE,
             ),
             # the.glades.201.family.matters.hdtv.xvid-fqm.avi

--- a/test.py
+++ b/test.py
@@ -688,6 +688,12 @@ class TestTV(unittest.TestCase):
                 "episode": 11,
                 "title": "This Is Your Brian On Drugs",
             },
+            "What.If.2021.S02E08.What.if.the.Avengers.Assembled.in.1602.1080p.DSNP.WEB-DL.DDP5.1.Atmos.H.264-FLUX.mkv": {
+                "series": "What If",
+                "season": 2,
+                "episode": 8,
+                "title": "What If The Avengers Assembled In 1602",
+            },
         }
 
         for filename, metadata in media.items():


### PR DESCRIPTION
Reorder the first two patterns in `nielsen.media.TV.patterns`. Filenames with a lot of 4 digit numbers in them were (series year, a year in the title, and a `1080p` resolution) were matching the first pattern with the year in the year in the title mistaken for the series year and the resolution tag being inferred as the season and episode numbers. Swapping the order of the first two patterns matches the less ambiguous `SxxExx` format first, which should prevent similar types of issues.

Add the problematic filename as a test case.

Resolve #110.