### PR TITLE
Update the configuration file after processing media

### DIFF
--- a/nielsen/bin/cli/main.py
+++ b/nielsen/bin/cli/main.py
@@ -16,7 +16,7 @@ import nielsen.bin.cli.tv
 
 import typer
 
-nielsen.config.load_config()
+config_files: list[str] = nielsen.config.load_config()
 logger: logging.Logger = logging.getLogger("nielsen")
 
 logging.basicConfig(
@@ -121,6 +121,11 @@ def process(
 
     for file in files:
         processor.process(Path(file))
+
+    # Due to the order in which configuration files are loaded, the most "personal"
+    # version will be at the end of the list.
+    if config_files:
+        nielsen.config.update_config(Path(config_files[-1]))
 
 
 def main() -> None:

--- a/nielsen/config.py
+++ b/nielsen/config.py
@@ -41,9 +41,10 @@ config[config.default_section] = {
 }
 
 
-def load_config(path: Optional[pathlib.Path] = None) -> ConfigParser:
-    """Load a configuration from a file. If no file path is provided, default
-    configuration file locations are used. Returns a ConfigParser object."""
+def load_config(path: Optional[pathlib.Path] = None) -> list[str]:
+    """Load a configuration from a file into the global configuration object. If no file
+    path is provided, default configuration file locations are used. Returns a list of
+    files loaded."""
 
     global config
     files: list[str]
@@ -58,7 +59,7 @@ def load_config(path: Optional[pathlib.Path] = None) -> ConfigParser:
         else:
             logger.error("Failed to load configuration from: %s", path)
 
-    return config
+    return files
 
 
 def write_config(path: pathlib.Path) -> None:
@@ -70,12 +71,12 @@ def write_config(path: pathlib.Path) -> None:
         config.write(file)
 
 
-def update_config(path: pathlib.Path) -> None:  # pragma: no cover
+def update_config(path: pathlib.Path) -> None:
     """Write new data to the config file without changing options already present in the
     config files. By re-reading the config files before writing, runtime options or
     other dynamic changes to the config will be reverted before the file is written."""
 
-    load_config()
+    load_config(path.expanduser())
     write_config(path.expanduser())
 
 

--- a/nielsen/media.py
+++ b/nielsen/media.py
@@ -229,11 +229,11 @@ class Media:
         # If chown gets a None value for user or group, it won't modify the existing
         # values. Use None as a fallback to leave things alone unless the user has
         # explicitly set a different value in their configuration.
-        chown(  # type: ignore
-            self.path,
-            user=config.get(self.section, "owner", fallback=None),  # type: ignore
-            group=config.get(self.section, "group", fallback=None),  # type: ignore
-        )
+        user: str | None = config.get(self.section, "owner", fallback=None)
+        group: str | None = config.get(self.section, "group", fallback=None)
+
+        if user or group:
+            chown(self.path, user, group)  # type: ignore
 
         return self.path
 
@@ -245,7 +245,7 @@ class Media:
         raise NotImplementedError
 
     @metadata.setter
-    def metadata(self, value: dict[str, Any]) -> None:
+    def metadata(self, metadata: dict[str, Any]) -> None:
         """Set the metadata property. Must be a dictionary, but subclasses should
         implement their own transformations (if any) by implementing this setter
         method."""


### PR DESCRIPTION
Update the most recently loaded configuration file after processing media with the CLI. This should add new options (e.g. media identifiers such as the TVMaze ID for a newly encountered series) while not changing options that were already defined in the file but were temporarily overwritten via command line options.

Resolve #112.