### PR TITLE
Resolve `mypy` errors

### DIFF
--- a/nielsen/bin/cli/tv.py
+++ b/nielsen/bin/cli/tv.py
@@ -79,7 +79,7 @@ def fetch(
 
     elif series_id and season:
         season_id: int = fetcher.get_season_id(series_id, season)
-        response: Response = fetcher.seasons_episodes(season_id)
+        response = fetcher.seasons_episodes(season_id)
         data = response.json()
 
         if raw:
@@ -88,7 +88,7 @@ def fetch(
             typer.echo(fetcher.pretty_season(data))
 
     elif series_id:
-        response: Response = fetcher.shows(series_id)
+        response = fetcher.shows(series_id)
         data = response.json()
 
         if raw:
@@ -150,7 +150,7 @@ def apply(
             raise typer.Exit(3)
 
         # Create a TV instance and attach metadata to it for the Fetcher to work with
-        media: nielsen.media.Media = nielsen.media.TV(
+        media: nielsen.media.TV = nielsen.media.TV(
             Path(files.pop()), series=series, season=season, episode=episode
         )
         fetcher.fetch(media)
@@ -163,9 +163,7 @@ def apply(
     episodes: list[dict[str, Any]] = response.json()
 
     for e, f in zip(episodes, files):
-        media: nielsen.media.Media = nielsen.media.TV(
-            Path(f), series=series, season=season
-        )
+        media = nielsen.media.TV(Path(f), series=series, season=season)
         typer.echo(
             f"Apply information from {series} Season {season} Episode {e['number']} to {media.path}"
         )

--- a/nielsen/fetcher.py
+++ b/nielsen/fetcher.py
@@ -4,7 +4,7 @@ import logging
 import urllib.parse
 from html.parser import HTMLParser
 from io import StringIO
-from typing import Any, Callable, Optional, Protocol, TypeVar
+from typing import Any, Callable, Optional, Protocol
 
 import requests
 
@@ -14,15 +14,12 @@ from nielsen.config import config
 logger: logging.Logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())
 
-# Define a generic Media type so the Fetcher Protocol will recognize Media subclasses
-MT = TypeVar("MT", bound=nielsen.media.Media, infer_variance=True)
-
 
 class Fetcher(Protocol):
     """Used to fetch metadata from an external source rather than infering it from the
     file name."""
 
-    def fetch(self, media: MT) -> None:
+    def fetch(self, media: nielsen.media.Media) -> None:
         """Fetch and update metadata using information from the given `Media` object."""
         ...
 
@@ -262,9 +259,9 @@ class TVMaze:
                     }
                 }:
                     logger.debug("Matched Network")
-                    name: str = name
-                    series_id: int = series_id
-                    premiered: str = premiered
+                    name = name
+                    series_id = series_id
+                    premiered = premiered
                     network: str = nw_name
                     country: str = (
                         nw_country.get("name", "Unknown") if nw_country else "Unknown"
@@ -280,11 +277,11 @@ class TVMaze:
                     }
                 }:
                     logger.debug("Matched Streaming")
-                    name: str = name
-                    series_id: int = series_id
-                    premiered: str = premiered
-                    network: str = wc_name
-                    country: str = (
+                    name = name
+                    series_id = series_id
+                    premiered = premiered
+                    network = wc_name
+                    country = (
                         wc_country.get("name", "Unknown") if wc_country else "Unknown"
                     )
 
@@ -297,22 +294,22 @@ class TVMaze:
                     }
                 }:
                     logger.debug("Matched Minimal")
-                    name: str = name
-                    series_id: int = series_id
-                    premiered: str = premiered
-                    network: str = "Unknown"
-                    country: str = "Unknown"
+                    name = name
+                    series_id = series_id
+                    premiered = premiered
+                    network = "Unknown"
+                    country = "Unknown"
 
                 # This should never happen
                 case _:
                     # NOTE: It may be better to simply skip these results.
                     logger.error("Unable to parse search result")
                     logger.debug(result)
-                    name: str = "Unknown"
-                    series_id: int = 0
-                    premiered: str = "Unknown"
-                    network: str = "Unknown"
-                    country: str = "Unknown"
+                    name = "Unknown"
+                    series_id = 0
+                    premiered = "Unknown"
+                    network = "Unknown"
+                    country = "Unknown"
 
             print(
                 f"{option}. {name} (Premiered: {premiered}, Network: {network}, Country: {country}, ID: {series_id})"
@@ -354,7 +351,7 @@ class TVMaze:
         pretty_episodes: list[str] = []
 
         for episode in data:
-            pretty_episodes.append(__class__.pretty_episode(episode))
+            pretty_episodes.append(TVMaze.pretty_episode(episode))
 
         return "\n\n".join(pretty_episodes)
 

--- a/nielsen/processor.py
+++ b/nielsen/processor.py
@@ -8,7 +8,6 @@ handles all changes to that Media instance."""
 
 from dataclasses import dataclass
 from enum import Enum
-from typing import Type
 import pathlib
 
 from nielsen.config import config
@@ -27,7 +26,7 @@ class Processor:
     construct instances of the given type. The `fetcher` is an instance of an object
     implementing the `Fetcher` Protocol."""
 
-    media_type: Type[nielsen.media.Media]
+    media_type: type[nielsen.media.Media]
     fetcher: nielsen.fetcher.Fetcher
 
     def process(self, path: pathlib.Path) -> nielsen.media.Media:
@@ -63,8 +62,8 @@ class ProcessorFactory:
     instance of this Factory will return a Processor with the given Media class and
     Fetcher instance."""
 
-    media_type: Type[nielsen.media.Media]
-    fetcher: Type[nielsen.fetcher.Fetcher]
+    media_type: type[nielsen.media.Media]
+    fetcher: type[nielsen.fetcher.Fetcher]
 
     def __call__(self) -> Processor:
         """Return a Processor for the given types."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ license = "GPL-3.0-or-later"
 name = "nielsen"
 readme = "README.md"
 repository = "https://github.com/IrishPrime/Nielsen/"
-version = "3.1.3"
+version = "3.1.4"
 
 [tool.poetry.dependencies]
 python = "^3.12"


### PR DESCRIPTION
Remove extraneous type annotations which "redefine" a variable with the same type.

Replace the generic Media Type (`MT`) with `nielsen.media.Media` in the `Fetcher` `Protocol`.

Use new syntax when annotating `type` variables (`type` vs. `typing.Type`).

Resolve #128.

Bump patch version.