### PR TITLE
change section name of default config to 'nielsen'

### DIFF
--- a/nielsen/config.py
+++ b/nielsen/config.py
@@ -17,7 +17,7 @@ CONFIG_FILE_LOCATIONS: list[str | pathlib.Path] = [
 config: ConfigParser = ConfigParser(converters={"path": pathlib.Path})
 
 # Set default options
-config[config.default_section] = {
+config['nielsen'] = {
     # Dry Run - Outputs results without actually modifying files
     "simulate": "False",
     # Fetch - Whether to query remote sources for information


### PR DESCRIPTION
Issue #131

Default config was using the `config.default_section` variable, which resolves to 'DEFAULT'. This caused issues with calls to `config.get` in bin/cli/{tv|main}.py which were using a hard coded string 'nielsen' as the section name. 