### PR TITLE
Make tests self-sufficient via `tmp_path` fixtures

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,11 +39,6 @@ jobs:
       - name: Install project
         run: uv sync --all-extras --dev
 
-      - name: Create dummy files for testing
-        run: |
-          touch fixtures/media.file
-          mkdir fixtures/{media,tv}
-
       - name: Run pytest
         run: |
           uv run pytest --maxfail=3 --disable-warnings

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,16 +7,64 @@ import pytest
 import nielsen.config
 
 
-@pytest.fixture(autouse=True)
-def config() -> Generator[ConfigParser, Any, Any]:
-    """Fixture to load Nielsen configuration for tests."""
+@pytest.fixture
+def media_library(tmp_path: pathlib.Path) -> pathlib.Path:
+    """Real directory under tmp_path used as the [media] library."""
 
-    nielsen.config.load_config(pathlib.Path("./fixtures/config.ini"))
+    d = tmp_path / "media"
+    d.mkdir()
+    return d
+
+
+@pytest.fixture
+def tv_library(tmp_path: pathlib.Path) -> pathlib.Path:
+    """Real directory under tmp_path used as the [tv] library."""
+
+    d = tmp_path / "tv"
+    d.mkdir()
+    return d
+
+
+@pytest.fixture
+def media_file(tmp_path: pathlib.Path) -> pathlib.Path:
+    """Real, empty file under tmp_path that tests can use as a Media path."""
+
+    f = tmp_path / "media.file"
+    f.touch()
+    return f
+
+
+@pytest.fixture(autouse=True)
+def config(
+    tmp_path: pathlib.Path,
+    media_library: pathlib.Path,
+    tv_library: pathlib.Path,
+) -> Generator[ConfigParser, Any, Any]:
+    """Load Nielsen configuration backed by tmp_path-rooted libraries."""
+
+    # Build the test config from the canonical fixture, but redirect every
+    # `library` path to a tmp_path-rooted directory so tests never read or
+    # write real on-disk fixtures.
+    parser: ConfigParser = ConfigParser()
+    parser.read(pathlib.Path("fixtures/config.ini"))
+    for section in ("nielsen", "media", "tv"):
+        if not parser.has_section(section):
+            parser.add_section(section)
+    parser["nielsen"]["library"] = str(tmp_path)
+    parser["media"]["library"] = str(media_library)
+    parser["tv"]["library"] = str(tv_library)
+
+    config_file: pathlib.Path = tmp_path / "config.ini"
+    with config_file.open("w") as f:
+        parser.write(f)
+
+    nielsen.config.load_config(config_file)
     yield nielsen.config.config
-    # Clear all options between uses
     nielsen.config.config.clear()
 
 
 @pytest.fixture
-def missing_file() -> pathlib.Path:
-    return pathlib.Path("fixtures/media/missing.file")
+def missing_file(tmp_path: pathlib.Path) -> pathlib.Path:
+    """Path under tmp_path that is guaranteed not to exist."""
+
+    return tmp_path / "missing" / "file"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -9,11 +9,13 @@ import nielsen.config
 
 
 @pytest.fixture
-def config_file() -> pathlib.Path:
+def config_file(tmp_path: pathlib.Path) -> pathlib.Path:
     """Return a Path object representing the location of the configuration file to be
     used with tests."""
 
-    return pathlib.Path("fixtures/config.ini")
+    config_file: pathlib.Path = tmp_path / "config.ini"
+    config_file.write_text("[unit tests]\nfoo = bar\n")
+    return config_file
 
 
 def test_load_config_no_arg_no_files(mocker):
@@ -33,7 +35,7 @@ def test_load_config_specific_file(config_file):
     """Load config from a specific file."""
 
     files: list[str] = nielsen.config.load_config(config_file)
-    assert files == ["fixtures/config.ini"]
+    assert files == [str(config_file)]
 
     assert nielsen.config.config.has_section(
         "unit tests"
@@ -42,20 +44,20 @@ def test_load_config_specific_file(config_file):
     assert nielsen.config.config.get("unit tests", "foo") == "bar"
 
 
-def test_load_config_missing_file(caplog):
+def test_load_config_missing_file(caplog, tmp_path: pathlib.Path):
     """Specify a missing configuration file to load."""
 
-    file: pathlib.Path = pathlib.Path("fixtures/missing.ini")
+    file: pathlib.Path = tmp_path / "missing.ini"
     nielsen.config.load_config(file)
     assert f"Failed to load configuration from: {file}" in caplog.text
 
 
-def test_write_config(mocker):
+def test_write_config(mocker, tmp_path: pathlib.Path):
     """Write the config to a file."""
 
     # This function just calls the ConfigParser.write() method, so there's not much
     # for us to test. Ensure our function writes data to the specified file.
-    file: pathlib.Path = pathlib.Path("fixtures/write-test.ini")
+    file: pathlib.Path = tmp_path / "write-test.ini"
     mock_open: MockType = mocker.patch("builtins.open")
     mock_write: MockType = mocker.patch("configparser.ConfigParser.write")
 

--- a/tests/test_media.py
+++ b/tests/test_media.py
@@ -12,17 +12,17 @@ import nielsen.media
 
 
 @pytest.fixture
-def good_path() -> nielsen.media.Media:
+def good_path(media_file: pathlib.Path) -> nielsen.media.Media:
     """Return a Media object with a valid file path."""
 
-    return nielsen.media.Media(pathlib.Path("fixtures/media.file"))
+    return nielsen.media.Media(media_file)
 
 
 @pytest.fixture
-def missing_file() -> nielsen.media.Media:
+def missing_media(missing_file: pathlib.Path) -> nielsen.media.Media:
     """Return a Media object with no file at the specified path."""
 
-    return nielsen.media.Media(pathlib.Path("fixtures/media/missing.file"))
+    return nielsen.media.Media(missing_file)
 
 
 @pytest.fixture
@@ -33,10 +33,10 @@ def non_file_path() -> nielsen.media.Media:
 
 
 @pytest.fixture
-def medias(good_path, missing_file, non_file_path) -> list[nielsen.media.Media]:
+def medias(good_path, missing_media, non_file_path) -> list[nielsen.media.Media]:
     return [
         good_path,
-        missing_file,
+        missing_media,
         non_file_path,
     ]
 
@@ -76,7 +76,7 @@ def test_match_no_match(good_path) -> None:
     assert good_path._match() == {}, "Return an empty dictionary."
 
 
-def test_get_library(good_path) -> None:
+def test_get_library(good_path, media_library: pathlib.Path) -> None:
     """Get the library property from the appropriate config section."""
 
     # Calling resolve on the Path we compare to also ensures the library property is
@@ -84,9 +84,9 @@ def test_get_library(good_path) -> None:
     assert (
         good_path.library == nielsen.config.config.getpath("media", "library").resolve()  # type: ignore
     ), "Should match option from tv section of config."
-    assert (
-        good_path.library == pathlib.Path("fixtures/media/").resolve()
-    ), "Should match known type-specific value."
+    assert good_path.library == media_library.resolve(), (
+        "Should match known type-specific value."
+    )
 
 
 def test_get_metadata(good_path) -> None:
@@ -233,15 +233,16 @@ def test_set_section(non_file_path) -> None:
 
 
 @pytest.mark.parametrize(
-    "location",
+    "as_string",
     [
-        pytest.param("fixtures/media/", id="string"),
-        pytest.param(pathlib.Path("fixtures/media/"), id="path"),
+        pytest.param(True, id="string"),
+        pytest.param(False, id="path"),
     ],
 )
-def test_set_library(good_path, location) -> None:
+def test_set_library(good_path, media_library: pathlib.Path, as_string: bool) -> None:
     """Set the library property to valid paths."""
 
+    location: str | pathlib.Path = str(media_library) if as_string else media_library
     good_path.library = location
     assert isinstance(good_path.library, pathlib.Path)
     assert good_path.library.is_dir()
@@ -265,16 +266,17 @@ def test_set_library_invalid(good_path, location) -> None:
 
 
 @pytest.mark.parametrize(
-    "path",
+    "as_string",
     [
-        pytest.param("fixtures/media.file", id="string"),
-        pytest.param(pathlib.Path("fixtures/media.file"), id="path"),
+        pytest.param(True, id="string"),
+        pytest.param(False, id="path"),
     ],
 )
-def test_set_path(path) -> None:
+def test_set_path(media_file: pathlib.Path, as_string: bool) -> None:
     """Set the path property of a Media object."""
 
-    media: nielsen.media.Media = nielsen.media.Media(path)
+    path: str | pathlib.Path = str(media_file) if as_string else media_file
+    media: nielsen.media.Media = nielsen.media.Media(path)  # type: ignore[arg-type]
     assert isinstance(media.path, pathlib.Path)
     assert media.path.is_file()
 

--- a/tests/test_tv.py
+++ b/tests/test_tv.py
@@ -2,13 +2,14 @@
 
 import logging
 import pathlib
+from collections.abc import Callable
 from configparser import ConfigParser
-from typing import Any, Callable, Pattern, TypedDict
+from re import Pattern
+from typing import Any, TypedDict
 
 import pytest
 from pytest_mock import MockerFixture, MockType
 
-import nielsen.config
 import nielsen.media
 
 
@@ -350,12 +351,10 @@ def test_get_metadata(fixt, request) -> None:
     }
 
 
-def test_get_orgdir(tv_all_data) -> None:
+def test_get_orgdir(tv_all_data, tv_library: pathlib.Path) -> None:
     """The orgdir should be the library, series name, then season."""
 
-    assert (
-        tv_all_data.orgdir == pathlib.Path("fixtures/tv/Ted Lasso/Season 01/").resolve()
-    )
+    assert tv_all_data.orgdir == tv_library / "Ted Lasso" / "Season 01"
 
 
 @pytest.mark.parametrize(
@@ -433,12 +432,17 @@ def test_rename_success(
     simulate: str,
     tv_good_metadata: nielsen.media.TV,
     config: ConfigParser,
+    tmp_path: pathlib.Path,
 ) -> None:
     """Successfully rename a file without moving it to a different directory."""
 
     # Set simulation, which controls whether the file is actually renamed, or the the
     # new path is returned without renaming
     config.set("nielsen", "simulate", simulate)
+
+    # Relocate the path under tmp_path so the touch/rename below operates on a real
+    # disk path that pytest will clean up rather than polluting fixtures/.
+    tv_good_metadata.path = tmp_path / tv_good_metadata.path.name
 
     # Ensure the source exists and the destination does not
     tv_good_metadata.path.touch(exist_ok=True)
@@ -485,7 +489,9 @@ def test_rename_file_exists(
     assert "File already named correctly." in caplog.text
 
 
-def test_organize_success(tv_factory, mocker: MockerFixture) -> None:
+def test_organize_success(
+    tv_factory, mocker: MockerFixture, tv_library: pathlib.Path
+) -> None:
     """Organize file, set and return new path."""
 
     # Mock the existence of the file on disk to avoid creating and removing
@@ -500,8 +506,8 @@ def test_organize_success(tv_factory, mocker: MockerFixture) -> None:
     # shutil.move moves a file and returns the destination path passed as an
     # argument. Mock it by just returning the input argument.
     mock_move.side_effect = lambda _, org: org
-    filename: str = "fixtures/tv/Ted Lasso -01.03- Trent Crimm: The Independent.mkv"
-    destination: str = "fixtures/tv/Ted Lasso/Season 01/Ted Lasso -01.03- Trent Crimm: The Independent.mkv"
+    filename: str = "Ted Lasso -01.03- Trent Crimm: The Independent.mkv"
+    destination: pathlib.Path = tv_library / "Ted Lasso" / "Season 01" / filename
 
     tv: nielsen.media.TV = tv_factory(
         filename,
@@ -513,7 +519,7 @@ def test_organize_success(tv_factory, mocker: MockerFixture) -> None:
         },
     )
 
-    assert tv.organize() == (pathlib.Path(destination).resolve())
+    assert tv.organize() == destination
 
     # The pathlib.Path.chmod and shutil.chown functions can be assumed to work properly,
     # we just need to assert that they were called with the correct values.
@@ -555,9 +561,9 @@ def test_str(tv_good_metadata: nielsen.media.TV) -> None:
 
     expected: str = "Ted Lasso -01.03- Trent Crimm: The Independent"
 
-    assert (
-        str(tv_good_metadata) == expected
-    ), "String representation should match display format"
+    assert str(tv_good_metadata) == expected, (
+        "String representation should match display format"
+    )
 
 
 def test_str_no_metadata(tv_no_metadata: Callable[[str], nielsen.media.TV]) -> None:


### PR DESCRIPTION
Remove the "Create dummy files for testing" step in the Tests workflow in favor of `pytest` fixtures that provision their own filesystem state under `tmp_path`. The autouse `config` fixture in `tests/conftest.py` now writes a temporary `config.ini` whose `[nielsen]`, `[media]`, and `[tv]` library paths are rooted in `tmp_path`, and exposes `media_library`, `tv_library`, and `media_file` fixtures to tests that need to reference those paths directly.

After this change, `git clone && uv sync && uv run pytest` passes on a fresh checkout with no manual setup, and `test_write_config` no longer pollutes the working tree with `fixtures/write-test.ini`.

Update dependencies.

Bump patch version.

Resolve #148.