### PR TITLE
Invalidate `setup-uv` cache on `uv.lock` changes

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,7 +27,7 @@ jobs:
           - "3.14"
 
     steps:
-      - name: Check out code
+      - name: Checkout code
         uses: actions/checkout@v4
 
       - name: Install uv and Python
@@ -35,6 +35,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           enable-cache: true
+          cache-dependency-glob: uv.lock
 
       - name: Install project
         run: uv sync --all-extras --dev


### PR DESCRIPTION
Set `cache-dependency-glob: uv.lock` on the `astral-sh/setup-uv` step so the cached dependency download is re-keyed when the lockfile changes, avoiding stale wheels surviving past a dependency bump until the cache TTL or runner image rolls.

Resolve #139.