### PR TITLE
Bump GitHub Actions to Node.js 24 compatible versions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,10 +28,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install uv and Python
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v8.1.0
         with:
           python-version: ${{ matrix.python-version }}
           enable-cache: true
@@ -45,7 +45,7 @@ jobs:
           uv run pytest --maxfail=3 --disable-warnings
 
       - name: Upload coverage report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: coverage-report-${{ matrix.python-version }}
           path: htmlcov


### PR DESCRIPTION
GitHub forces Node.js 24 on June 2, 2026 and removes the Node.js 20 runtime entirely on September 16, 2026. The actions pinned in `tests.yml` all still ship with Node.js 20, which produces a deprecation warning on every run today and will start breaking once the default flips.

- `actions/checkout`: `v4` → `v6` (`v5` was the Node 24 cutover; `v6` is the current major).
- `actions/upload-artifact`: `v4` → `v7` (`v5` added Node 24 support; `v7` is current).
- `astral-sh/setup-uv`: `v5` → `v8.1.0`. `v8` dropped the floating `@v8` major tag for supply-chain reasons, so we have to pin to an immutable version.

Resolve #156.