### PR TITLE
Enable per-test coverage contexts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,11 @@ addopts = "-ra --import-mode=importlib --cov=nielsen --cov-report=html --cov-rep
 
 [tool.coverage.run]
 branch = true
+dynamic_context = "test_function"
 parallel = true
+
+[tool.coverage.html]
+show_contexts = true
 
 [tool.coverage.report]
 show_missing = true


### PR DESCRIPTION
Set `dynamic_context = "test_function"` so `coverage` records which test exercised each covered line, and `show_contexts = true` under `[tool.coverage.html]` so the recorded contexts are actually surfaced in the HTML report. Without the HTML setting the contexts are captured but invisible.

After running `pytest`, each covered line in `htmlcov/` exposes the list of originating tests, making "why is this branch covered?" and "which tests pull in this expensive import?" questions answerable from the report.

Resolve #143.