### PR TITLE
Make Fetcher Protocol generic on the media type

### DIFF
--- a/nielsen/fetcher.py
+++ b/nielsen/fetcher.py
@@ -15,11 +15,11 @@ logger: logging.Logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())
 
 
-class Fetcher(Protocol):
+class Fetcher[M: nielsen.media.Media](Protocol):
     """Used to fetch metadata from an external source rather than infering it from the
     file name."""
 
-    def fetch(self, media: nielsen.media.Media) -> None:
+    def fetch(self, media: M) -> None:
         """Fetch and update metadata using information from the given `Media` object."""
         ...
 

--- a/nielsen/processor.py
+++ b/nielsen/processor.py
@@ -6,13 +6,14 @@ instance and manually calling all of their individual methods, Processors provid
 convenience method (process) which creates a Media instance of the desired type and
 handles all changes to that Media instance."""
 
+import pathlib
 from dataclasses import dataclass
 from enum import Enum
-import pathlib
+from typing import Any
 
-from nielsen.config import config
 import nielsen.fetcher
 import nielsen.media
+from nielsen.config import config
 
 
 class MediaType(str, Enum):
@@ -20,16 +21,16 @@ class MediaType(str, Enum):
 
 
 @dataclass
-class Processor:
+class Processor[M: nielsen.media.Media]:
     """A convenience class to handle all the Media and Fetcher operations required to
     manage an individual file. The `media_type` is a Media class and is used to
     construct instances of the given type. The `fetcher` is an instance of an object
     implementing the `Fetcher` Protocol."""
 
-    media_type: type[nielsen.media.Media]
-    fetcher: nielsen.fetcher.Fetcher
+    media_type: type[M]
+    fetcher: nielsen.fetcher.Fetcher[M]
 
-    def process(self, path: pathlib.Path) -> nielsen.media.Media:
+    def process(self, path: pathlib.Path) -> M:
         """Convenience function to process Media for storage in its library, respecting the configuration
         options (so some steps may be skipped).
         1. Infer metadata based on the Media type.
@@ -40,7 +41,7 @@ class Processor:
         """
 
         # Create an instance of the appropriate Media subclass
-        media: nielsen.media.Media = self.media_type(path)
+        media: M = self.media_type(path)
 
         media.infer()
 
@@ -57,20 +58,20 @@ class Processor:
 
 
 @dataclass
-class ProcessorFactory:
+class ProcessorFactory[M: nielsen.media.Media]:
     """A Factory class for Processors. Given a Media and Fetcher class, calling an
     instance of this Factory will return a Processor with the given Media class and
     Fetcher instance."""
 
-    media_type: type[nielsen.media.Media]
-    fetcher: type[nielsen.fetcher.Fetcher]
+    media_type: type[M]
+    fetcher: type[nielsen.fetcher.Fetcher[M]]
 
-    def __call__(self) -> Processor:
+    def __call__(self) -> Processor[M]:
         """Return a Processor for the given types."""
 
         return Processor(self.media_type, self.fetcher())
 
 
-PROCESSOR_FACTORIES: dict[MediaType, ProcessorFactory] = {
+PROCESSOR_FACTORIES: dict[MediaType, ProcessorFactory[Any]] = {
     MediaType.TV: ProcessorFactory(nielsen.media.TV, nielsen.fetcher.TVMaze),
 }


### PR DESCRIPTION
Parameterize `Fetcher` on the media subtype it handles so subclass-specific implementations (currently `TVMaze`, future fetchers for other media types) can declare narrower `fetch` signatures without failing type checks.

The previous declaration:

    class Fetcher(Protocol):
        def fetch(self, media: Media) -> None: ...

required every implementation to accept any `Media`. `TVMaze.fetch` narrows to `TV`, which means it does not satisfy the protocol; passing a generic `Media` to `TVMaze.fetch` would be a type error. `mypy` was (correctly) flagging this with a `[arg-type]` error at the `PROCESSOR_FACTORIES` `dict` literal.

The new declaration uses Python 3.12 generic class syntax:

    class Fetcher[M: Media](Protocol):
        def fetch(self, media: M) -> None: ...

`Processor` and `ProcessorFactory` are parameterized to match, so the type relationship between a factory's `media_type` and its `fetcher` is now expressed in the type system instead of being implicit. The heterogeneous `PROCESSOR_FACTORIES` `dict` uses `ProcessorFactory[Any]` as its value type.

Internally, `Processor.process` now returns `M` instead of `Media` (callers see a narrower type at no cost) and the local annotation on `media` was tightened from `Media` to `M` so the narrowing carries through to `self.fetcher.fetch(media)`.

Resolve #161.