### PR TITLE
Remove redundant self-assignments in `TVMaze.pick_series`

### DIFF
--- a/nielsen/config.py
+++ b/nielsen/config.py
@@ -3,7 +3,6 @@
 import logging
 import pathlib
 from configparser import ConfigParser
-from typing import Optional
 
 logger: logging.Logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())
@@ -43,12 +42,11 @@ config[config.default_section] = {
 }
 
 
-def load_config(path: Optional[pathlib.Path] = None) -> list[str]:
+def load_config(path: pathlib.Path | None = None) -> list[str]:
     """Load a configuration from a file into the global configuration object. If no file
     path is provided, default configuration file locations are used. Returns a list of
     files loaded."""
 
-    global config
     files: list[str]
 
     if not path:
@@ -66,8 +64,6 @@ def load_config(path: Optional[pathlib.Path] = None) -> list[str]:
 
 def write_config(path: pathlib.Path) -> None:
     """Write the global configuration object to the given `path`."""
-
-    global config
 
     with open(path, mode="w") as file:
         config.write(file)

--- a/nielsen/fetcher.py
+++ b/nielsen/fetcher.py
@@ -2,9 +2,10 @@
 
 import logging
 import urllib.parse
+from collections.abc import Callable
 from html.parser import HTMLParser
 from io import StringIO
-from typing import Any, Callable, Optional, Protocol
+from typing import Any, Protocol
 
 import requests
 
@@ -34,7 +35,7 @@ class TVMaze:
         """Fetch metadata from TVMaze, update the metadata of the provided Media object,
         record the series ID in the config."""
 
-        series_id: Optional[int] = self.get_series_id(
+        series_id: int | None = self.get_series_id(
             media.series, config.getboolean("nielsen", "interactive")
         )
 
@@ -133,7 +134,7 @@ class TVMaze:
         URL: /shows/:id/episodebynumber?season=:season&number=:number.
         """
 
-        series_id: Optional[int] = self.get_series_id(media.series)
+        series_id: int | None = self.get_series_id(media.series)
         episode_title: str = ""
 
         if not series_id:
@@ -176,9 +177,9 @@ class TVMaze:
         request: str = (
             f"{self.SERVICE}/search/shows/?q={urllib.parse.quote_plus(series)}"
         )
-        logging.debug("Series: %s\nRequest: %r", series, request)
+        logger.debug("Series: %s\nRequest: %r", series, request)
         response: requests.Response = requests.get(request)
-        logging.debug(response)
+        logger.debug(response)
 
         return response
 
@@ -259,9 +260,6 @@ class TVMaze:
                     }
                 }:
                     logger.debug("Matched Network")
-                    name = name
-                    series_id = series_id
-                    premiered = premiered
                     network: str = nw_name
                     country: str = (
                         nw_country.get("name", "Unknown") if nw_country else "Unknown"
@@ -277,9 +275,6 @@ class TVMaze:
                     }
                 }:
                     logger.debug("Matched Streaming")
-                    name = name
-                    series_id = series_id
-                    premiered = premiered
                     network = wc_name
                     country = (
                         wc_country.get("name", "Unknown") if wc_country else "Unknown"
@@ -294,9 +289,6 @@ class TVMaze:
                     }
                 }:
                     logger.debug("Matched Minimal")
-                    name = name
-                    series_id = series_id
-                    premiered = premiered
                     network = "Unknown"
                     country = "Unknown"
 
@@ -331,13 +323,11 @@ class TVMaze:
         This is intended to work with the results of the TVMaze `/shows/:id`
         endpoint."""
 
-        return "\n".join(
-            (
-                f"{data['name']} - ID: {data['id']} - {data['url']}",
-                f"Premiered: {data['premiered']} - Status: {data['status']}",
-                f"{strip_tags(data['summary'])}",
-            )
-        )
+        return "\n".join((
+            f"{data['name']} - ID: {data['id']} - {data['url']}",
+            f"Premiered: {data['premiered']} - Status: {data['status']}",
+            f"{strip_tags(data['summary'])}",
+        ))
 
     @staticmethod
     def pretty_season(data: list[dict[str, Any]]) -> str:
@@ -364,13 +354,11 @@ class TVMaze:
         This is intended to work with the results of the TVMaze `/seasons/:id/episodes`
         and `/shows/:id/episodebynumber?season=:season&number=:number` endpoints."""
 
-        return "\n".join(
-            (
-                f"{data['season']}x{data['number']} - {data["name"]}",
-                f"{data['url']}",
-                f"{strip_tags(data['summary'])}",
-            )
-        )
+        return "\n".join((
+            f"{data['season']}x{data['number']} - {data['name']}",
+            f"{data['url']}",
+            f"{strip_tags(data['summary'])}",
+        ))
 
 
 class MLStripper(HTMLParser):


### PR DESCRIPTION
The `case` patterns already bind `name`, `series_id`, and `premiered` in the enclosing scope, so the `name = name` / `series_id = series_id` / `premiered = premiered` lines were no-ops. Remove them to resolve nine `PLW0127` warnings from `ruff`.

Remove unnecessary `global` to resolve two `PLW0602` warnings.

Use more modern `| None` type annotation rather than `typing.Optional`.

Resolve #165.