### PR TITLE
Add TVMaze response `TypedDicts` to `fetcher` module

### DIFF
--- a/nielsen/fetcher.py
+++ b/nielsen/fetcher.py
@@ -5,7 +5,7 @@ import urllib.parse
 from collections.abc import Callable
 from html.parser import HTMLParser
 from io import StringIO
-from typing import Any, Protocol
+from typing import Any, Protocol, TypedDict
 
 import requests
 
@@ -14,6 +14,43 @@ from nielsen.config import config
 
 logger: logging.Logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())
+
+
+class WebChannel(TypedDict, total=False):
+    id: int
+    name: str
+    country: dict[str, Any] | None
+    officialSite: str
+
+
+class Image(TypedDict, total=False):
+    medium: str
+    original: str
+
+
+class Show(TypedDict, total=False):
+    id: int
+    name: str
+    premiered: str | None
+    network: dict[str, Any] | None
+    webChannel: WebChannel | None
+    image: Image | None
+    summary: str | None
+
+
+class Season(TypedDict, total=False):
+    id: int
+    url: str
+    number: int
+    name: str
+    episodeOrder: int
+    premiereDate: str | None
+    endDate: str | None
+    network: dict[str, Any] | None
+    webChannel: WebChannel | None
+    image: Image | None
+    summary: str | None
+    _links: dict[str, Any]
 
 
 class Fetcher[M: nielsen.media.Media](Protocol):


### PR DESCRIPTION
Define `TypedDict` shapes for the TVMaze JSON payloads consumed by the fetcher (`WebChannel`, `Image`, `Show`, and `Season`). The types document the contract we expect from TVMaze and let `mypy` flag field-name typos that today silently return `None`.

`total=False` is set on every `TypedDict` because TVMaze frequently omits fields (shows with no `webChannel`, seasons mid-air with no `endDate`, etc.). Inner annotations use `dict[str, Any]` rather than bare `dict` to match the cleanup in #141.

The types live inline at the top of `nielsen/fetcher.py` rather than in a separate module, matching the project's single-file-module pattern (`config.py`, `processor.py`, `media.py`) and keeping the types co-located with their only consumer. No fetcher method bodies are annotated against the new types yet; that adoption is a follow-up so this PR stays a strictly-additive diff.

Resolve #147.